### PR TITLE
[sejin] Design : 피그마 디자인대로 listcard 디자인 변경

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,33 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'plugin:react/recommended',
+    'airbnb',
+  ],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 12,
+    sourceType: 'module',
+  },
+  plugins: [
+    'react',
+  ],
+  rules: {
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    'import/prefer-default-export': 'off',
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  },
+  overrides: [
+    {
+      files: ['src/app/layout.tsx'],
+      rules: {
+        'react-refresh/only-export-components': 'off',
+      },
+    },
+  ],
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,26 @@
+// eslint.config.mjs
+import storybook from "eslint-plugin-storybook";
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
+
+export default defineConfig([
+  globalIgnores(["dist"]),
+  {
+    files: ["**/*.{ts,tsx}"],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs["recommended-latest"],
+      reactRefresh.configs.vite,
+    ],
+    plugins: { storybook }, // storybook 플러그인 등록
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+]);

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -218,22 +218,91 @@ export default function DemoPage() {
                 <h2 className="typo-18-b mb-4">List</h2>
                 <div className="grid gap-4">
                   <ListCard
-                    thumbnail="https://placehold.co/96"
+                    thumbnail="https://placehold.co/96x96"
                     title="열기구 투어"
-                    subtitle="성인 2명 · 09:00~13:30"
+                    subtitle="0000.00.00 · 11:00 - 12:30"
                     status="confirmed"
-                    price="₩ 35,000~"
-                    priceSub="세금 포함"
-                    ctaLabel="자세히"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    ctaLabel="예약 하기"
+                    onClickCTA={() => console.log('예약하기 클릭')}
                   />
                   <ListCard
-                    thumbnail="https://placehold.co/96"
+                    thumbnail="https://placehold.co/96x96"
                     title="사막 지프투어"
-                    subtitle="성인 1명 · 10:00~12:00"
+                    subtitle="0000.00.00 · 11:00 - 12:30"
                     status="pending"
-                    price="₩ 49,000"
-                    priceSub="현장결제"
-                    ctaLabel="확인"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    ctaLabel="예약 하기"
+                    onClickCTA={() => console.log('예약하기 클릭')}
+                  />
+                  <ListCard
+                    thumbnail="https://placehold.co/96x96"
+                    title="서핑 레슨"
+                    subtitle="0000.00.00 · 11:00 - 12:30"
+                    status="canceled"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    onClickCTA={() => console.log('예약하기 클릭')}
+                  />
+                  <ListCard
+                    thumbnail="https://placehold.co/96x96"
+                    title="패러글라이딩"
+                    subtitle="0000.00.00 · 11:00 - 12:30"
+                    status="completed"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    ctaLabel="후기 작성"
+                    onClickCTA={() => console.log('후기 작성 클릭')}
+                  />
+
+                  {/* PC 버전들 */}
+                  <ListCard
+                    variant="pc"
+                    thumbnail="https://placehold.co/128x128"
+                    title="title"
+                    subtitle="0000.00.00 · 11:00 - 12:30"
+                    status="confirmed"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    showActions={true}
+                  />
+
+                  <ListCard
+                    variant="pc"
+                    thumbnail="https://placehold.co/128x128"
+                    title="title"
+                    subtitle="0000.00.00 · 11:00 - 12:30"
+                    status="confirmed"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    ctaLabel="후기 작성"
+                    showActions={false}
+                  />
+
+                  {/* 모바일 버전들 */}
+                  <ListCard
+                    variant="mobile"
+                    thumbnail="https://placehold.co/300x128"
+                    title="title"
+                    subtitle="11:00 - 12:30"
+                    status="confirmed"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    showActions={true}
+                  />
+
+                  <ListCard
+                    variant="mobile"
+                    thumbnail="https://placehold.co/300x128"
+                    title="title" 
+                    subtitle="11:00 - 12:30"
+                    status="confirmed"
+                    price="₩ 35,000"
+                    priceSub="/00명"
+                    ctaLabel="후기 작성"
+                    showActions={false}
                   />
                 </div>
               </section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import type { Metadata } from "next";
 import "../styles/globals.css";
 

--- a/src/components/ListCard.stories.tsx
+++ b/src/components/ListCard.stories.tsx
@@ -1,73 +1,109 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import ListCard from './ListCard';
+import type { Meta, StoryObj } from "@storybook/react";
+import ListCard from "./ListCard";
 
 const meta = {
-  title: 'Components/ListCard',
+  title: "Components/ListCard",
   component: ListCard,
-  parameters: { layout: 'padded' }, // or 'fullscreen'
+  parameters: { layout: "padded" },
+
+  // ✅ 기본 args: 필수값 & 자주 쓰는 값들
   args: {
-    // ✅ 컴포넌트에서 요구하는 필수 값들을 “실제처럼” 채우기
-    thumbnail: 'https://placehold.co/96x96',   // thumbnailSrc → thumbnail로 수정
-    title: '연가구 투어',
-    subtitle: '성인 2명 · 09:00–13:30',
-    price: '₩ 35,000~',              // priceText → price
-    priceSub: '세금 포함',           // 추가 가격 정보
-    status: 'confirmed',             // badge → status (ReservationStatus 타입)
-    ctaLabel: '자세히',              // actionText → ctaLabel
-    onClickCTA: () => console.log('CTA 클릭'),
+    thumbnail: "https://placehold.co/300x200",
+    title: "연가구 투어",
+    subtitle: "성인 2명 · 09:00–13:30",
+    price: "₩ 35,000",
+    dateText: "0000.00.00",
+    timeText: "11:00 - 12:30",
+    peopleText: "00명",
+    status: "confirmed",
+    variant: "pc",
+  },
+
+  // ✅ 스토리북 Controls 설정
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["pending", "confirmed", "declined", "canceled", "completed"],
+    },
+    variant: {
+      control: "inline-radio",
+      options: ["pc", "mobile"],
+    },
+    forceMobileState: {
+      control: "inline-radio",
+      options: ["done", "ing"],
+    },
+    actionsDisabled: { control: "boolean" },
   },
 } satisfies Meta<typeof ListCard>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/* ──────────────────────────────── PC 시안 ──────────────────────────────── */
+
 export const Primary: Story = {
   args: {
-    thumbnail: 'https://placehold.co/96x96',
-    title: '연가구 투어',
-    subtitle: '성인 2명 · 09:00–13:30',
-    price: '₩ 35,000~',
-    status: 'confirmed',
-    ctaLabel: '자세히'
-  }
+    priceSub: "세금 포함",
+    ctaLabel: "후기 작성",
+    onClickCTA: () => console.log("후기 작성 클릭"),
+  },
 };
 
 export const Pending: Story = {
   args: {
-    thumbnail: 'https://placehold.co/96x96',
-    title: '열기구 체험',
-    subtitle: '성인 4명 · 14:00–18:00',
-    price: '₩ 85,000',
-    priceSub: '세금 포함',
-    status: 'pending',
-    ctaLabel: '확인하기'
-  }
+    title: "열기구 체험",
+    subtitle: "성인 4명 · 14:00–18:00",
+    price: "₩ 85,000",
+    priceSub: "세금 포함",
+    status: "pending",
+    ctaLabel: "확인하기",
+  },
 };
 
 export const Canceled: Story = {
   args: {
-    thumbnail: 'https://placehold.co/96x96',
-    title: '서핑 레슨',
-    price: '₩ 45,000',
-    status: 'canceled'
-  }
+    title: "서핑 레슨",
+    price: "₩ 45,000",
+    status: "canceled",
+  },
 };
 
 export const WithActionHandler: Story = {
   args: {
-    thumbnail: 'https://placehold.co/96x96',
-    title: '연가구 투어',
-    subtitle: '성인 2명 · 09:00–13:30',
-    price: '₩ 35,000~',
-    status: 'confirmed',
-    ctaLabel: '자세히',
-    onClickCTA: () => alert('자세히 클릭'),  // onClickAction → onClickCTA
+    ctaLabel: "자세히 보기",
+    onClickCTA: () => alert("자세히 클릭"),
   },
 };
 
 export const LongTexts: Story = {
   args: {
-    title: '글자가 아주 길 때는 이렇게 말줄임 처리가 되는지 테스트합니다',
-    subtitle: '설명도 길 때 한 줄/두 줄 클램프가 적용되는지 확인합니다',
+    title: "글자가 아주 길 때는 이렇게 말줄임 처리가 되는지 테스트합니다",
+    subtitle:
+      "설명도 길 때 한 줄 혹은 두 줄로 클램프가 적용되는지 확인합니다. 테스트 테스트 테스트",
+  },
+};
+
+/* ──────────────────────────────── 모바일 시안 ──────────────────────────────── */
+
+export const MobileCompleted: Story = {
+  args: {
+    variant: "mobile",
+    status: "completed",
+    title: "열기구 체험 (완료)",
+    price: "₩ 35,000",
+    subtitle: "성인 2명 · 11:00–12:30",
+    ctaLabel: "후기 작성",
+  },
+};
+
+export const MobileProgress: Story = {
+  args: {
+    variant: "mobile",
+    status: "confirmed",
+    title: "열기구 체험 (진행중)",
+    price: "₩ 35,000",
+    subtitle: "성인 2명 · 11:00–12:30",
+    forceMobileState: "ing", // ✅ 진행중 상태 강제
   },
 };

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -36,6 +36,8 @@ export interface ListCardProps {
   // 레이아웃
   variant?: "pc" | "mobile";
 
+  showActions?: boolean;
+
   // 모바일 테스트용
   forceMobileState?: MobileState;
   actionsDisabled?: boolean;

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -10,87 +10,219 @@ export type ReservationStatus =
   | "canceled"
   | "completed";
 
+type MobileState = "done" | "ing"; // done=후기작성 / ing=예약변경·취소
+
 export interface ListCardProps {
+  // 공통 필수
   thumbnail: string;
   title: string;
-  subtitle?: string; // 예: 인원/시간 등
-  status?: ReservationStatus; // API 상태값 그대로 받음
-  price: string; // "₩ 35,000~"
-  priceSub?: string; // "세금 포함" 등
-  ctaLabel?: string; // 버튼 텍스트
+  price: string;
+
+  // 공통 선택
+  subtitle?: string;        // 보조정보(인원/장소/시간 등)
+  status?: ReservationStatus;
+  priceSub?: string;        // "세금 포함" 등
+  peopleText?: string;      // "00명"
+  dateText?: string;        // "0000.00.00"
+  timeText?: string;        // "11:00 - 12:30"
   className?: string;
+
+  // 액션
+  ctaLabel?: string;        // 기본 "후기 작성"
   onClickCTA?: () => void;
+  onClickChange?: () => void;
+  onClickCancel?: () => void;
+
+  // 레이아웃
+  variant?: "pc" | "mobile";
+
+  // 모바일 테스트용
+  forceMobileState?: MobileState;
+  actionsDisabled?: boolean;
 }
 
-function mapReservationStatus(apiStatus: ReservationStatus | undefined) {
-  switch (apiStatus) {
-    case "pending":
-      return { variant: "warning" as const, text: "확인 요청" };
-    case "confirmed":
-      return { variant: "success" as const, text: "예약 완료" };
-    case "declined":
-      return { variant: "error" as const, text: "거절됨" };
-    case "canceled":
-      return { variant: "default" as const, text: "취소됨" };
-    case "completed":
-      return { variant: "info" as const, text: "이용 완료" };
-    default:
-      return { variant: "default" as const, text: "" };
+/** 상태 → 배지 매핑 */
+function badge(s?: ReservationStatus) {
+  switch (s) {
+    case "pending":   return { v: "warning" as const, t: "확인 요청" };
+    case "confirmed": return { v: "success" as const,  t: "예약 완료" };
+    case "declined":  return { v: "error" as const,    t: "거절됨" };
+    case "canceled":  return { v: "default" as const,  t: "취소됨" };
+    case "completed": return { v: "success" as const,  t: "예약 완료" };
+    default:          return { v: "default" as const,  t: "" };
   }
 }
 
 export default function ListCard({
   thumbnail,
   title,
+  price,
   subtitle,
   status,
-  price,
   priceSub,
-  ctaLabel = "자세히",
+  peopleText = "00명",
+  dateText = "0000.00.00",
+  timeText = "11:00 - 12:30",
   className,
+  ctaLabel = "후기 작성",
   onClickCTA,
+  onClickChange,
+  onClickCancel,
+  variant = "pc",
+  forceMobileState,
+  actionsDisabled,
 }: ListCardProps) {
-  const { variant, text } = mapReservationStatus(status);
+  const { v: tagVariant, t: tagText } = badge(status);
+  const mobileState: MobileState =
+    forceMobileState ?? (status === "completed" ? "done" : "ing");
+  const hasSubtitle = !!subtitle?.trim();
 
+  const ProgressActions = (
+    <div className={clsx(variant === "mobile" ? "grid grid-cols-2 gap-3" : "flex gap-2")}>
+      <button
+        className={clsx(
+          "typo-12-m rounded-xl px-3",
+          variant === "mobile" ? "h-11 w-full" : "h-9",
+          actionsDisabled
+            ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+            : "bg-gray-100 text-text-secondary hover:bg-gray-200"
+        )}
+        onClick={actionsDisabled ? undefined : onClickChange}
+      >
+        예약 변경
+      </button>
+      <button
+        className={clsx(
+          "typo-12-m rounded-xl px-3",
+          variant === "mobile" ? "h-11 w-full" : "h-9",
+          actionsDisabled
+            ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+            : "bg-gray-100 text-text-secondary hover:bg-gray-200"
+        )}
+        onClick={actionsDisabled ? undefined : onClickCancel}
+      >
+        예약 취소
+      </button>
+    </div>
+  );
+
+  const DoneCTA = (
+    <Button
+      label={ctaLabel}
+      size={variant === "mobile" ? "md" : "sm"}
+      variant="primary"
+      className={clsx(variant === "mobile" ? "w-full h-11 rounded-xl" : "h-9 rounded-xl")}
+      onClick={onClickCTA}
+    />
+  );
+
+  /* ───────────── MOBILE (시안 동일: 309/139, 38px 겹침, 버튼 410px) ───────────── */
+  if (variant === "mobile") {
+    // 고정값: 카드 309, 이미지 139, 카드가 가리는 폭 38 → 밖으로 보이는 폭 101
+    // 총 너비(버튼 기준) = 309 + 101 = 410
+    return (
+      <div className={clsx("relative w-[410px]", className)}>
+        {/* 이미지: 카드 뒤에 깔리고, 오른쪽으로 101px 노출되도록 right:0에 배치 */}
+        <div className="absolute right-0 top-0 -z-10 w-[139px] h-[139px] rounded-[20px] overflow-hidden">
+          <img src={thumbnail} alt="" className="w-full h-full object-cover" loading="lazy" />
+        </div>
+
+        {/* 카드: 폭 309, 높이 139, 이미지 위 38px 덮음 */}
+        <div className="relative z-0 h-[139px] w-[309px] rounded-[20px] bg-white border border-gray-100 shadow-[0_2px_8px_rgba(0,0,0,0.06)] overflow-hidden">
+          <div className="h-full px-5 py-5 flex flex-col justify-between">
+            <div>
+              {tagText && (
+                <Tag
+                  variant={tagVariant}
+                  size="sm"
+                  className="inline-flex items-center h-fit px-2 py-[2px] mb-2"
+                >
+                  {tagText}
+                </Tag>
+              )}
+              <h4 className="typo-16-b text-text-primary mb-1">{title}</h4>
+
+              {/* subtitle이 있으면 날짜/시간 줄 숨김 */}
+              {hasSubtitle ? (
+                <p className="typo-12-m text-text-secondary mb-1 line-clamp-2">{subtitle}</p>
+              ) : (
+                <p className="typo-12-m text-text-secondary">
+                  {dateText}
+                  <span className="mx-2">·</span>
+                  {timeText}
+                </p>
+              )}
+            </div>
+
+            <div className="mt-2">
+              <span className="typo-16-b text-text-primary">{price}</span>
+              {priceSub && <span className="typo-12-m text-text-secondary ml-1">{priceSub}</span>}
+              <span className="typo-12-m text-text-secondary ml-1">/ {peopleText}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 버튼: 카드+이미지 전체 폭(410px)에 맞춤 */}
+        <div className="mt-3 w-[410px]">
+          {mobileState === "done" ? DoneCTA : ProgressActions}
+        </div>
+      </div>
+    );
+  }
+
+  /* ───────────── PC ───────────── */
   return (
     <div
       className={clsx(
-        "rounded-2xl bg-white dark:bg-gray-900 border border-border-default p-4 flex items-center gap-4",
+        "flex items-stretch bg-white rounded-[20px] shadow-[0_2px_8px_rgba(0,0,0,0.05)] border border-gray-100 overflow-hidden",
         className
       )}
     >
-      <img
-        src={thumbnail}
-        alt=""
-        className="w-24 h-24 rounded-xl object-cover shrink-0"
-        loading="lazy"
-      />
-
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          {text && <Tag variant={variant}>{text}</Tag>}
-        </div>
-
-        <div className="mt-1 flex items-center justify-between gap-4">
-          <div className="min-w-0">
-            <h4 className="typo-16-b truncate">{title}</h4>
-            {subtitle && (
-              <p className="typo-12-m text-text-secondary mt-0.5 truncate">
-                {subtitle}
+      {/* 좌 텍스트 */}
+      <div className="flex-1 p-5 flex flex-col justify-between">
+        <div className="space-y-2">
+          {tagText && (
+            <Tag
+              variant={tagVariant}
+              size="sm"
+              className="inline-flex items-center h-fit px-2 py-[2px]"
+            >
+              {tagText}
+            </Tag>
+          )}
+          <div>
+            <h4 className="typo-16-b text-text-primary mb-1">{title}</h4>
+            {hasSubtitle ? (
+              <p className="typo-12-m text-text-secondary">{subtitle}</p>
+            ) : (
+              <p className="typo-12-m text-text-secondary mt-1">
+                {dateText}
+                <span className="mx-2">·</span>
+                {timeText}
               </p>
             )}
           </div>
+        </div>
 
-          <div className="text-right shrink-0">
-            <div className="typo-16-b">{price}</div>
-            {priceSub && (
-              <div className="typo-12-m text-text-secondary">{priceSub}</div>
-            )}
+        <div className="flex justify-between items-center mt-4">
+          <div>
+            <span className="typo-16-b text-text-primary">{price}</span>
+            {priceSub && <span className="typo-12-m text-text-secondary ml-1">{priceSub}</span>}
+            <span className="typo-12-m text-text-secondary ml-1">/ {peopleText}</span>
           </div>
+          {status === "completed" ? DoneCTA : ProgressActions}
         </div>
       </div>
 
-      <Button label={ctaLabel} size="sm" onClick={onClickCTA} />
+      {/* 우 이미지: 카드 내부에서 꽉 차게, 오른쪽 라운드만 */}
+      <div className="w-[180px] shrink-0 overflow-hidden">
+        <img
+          src={thumbnail}
+          alt=""
+          className="w-full h-full object-cover rounded-r-[20px]"
+          loading="lazy"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/StarRatingInput.stories.tsx
+++ b/src/components/StarRatingInput.stories.tsx
@@ -11,6 +11,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+
 export const Primary: Story = { 
   args: {
     initialRating: 3,

--- a/src/context/themeHelpers.ts
+++ b/src/context/themeHelpers.ts
@@ -1,0 +1,4 @@
+export function deriveSomething(x: string) {
+  // ...
+  return x;
+}


### PR DESCRIPTION
feat: 전체 컴포넌트 및 데모 페이지 완성

주요 변경사항:
- ListCard: PC/모바일 반응형 레이아웃 구현 (가로/세로)
- 모든 스토리북 컴포넌트 타입 에러 수정
  * Card: children prop 추가
  * CheckItem: label prop 추가
  * Modal: open prop 추가
  * StarRatingInput: initialRating, onChange props 추가
- Tag 컴포넌트 사용법 수정 (label → children)