### PR TITLE
[feature/experience] categorySelect 컴포넌트 제작 및 mock데이터 구조 정의, 내 체험 관리 페이지 UI 완성

### DIFF
--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperienceEditPage() {
+  return <div>체험 수정 폼</div>;
+}

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperienceRegisterPage() {
+  return <div>체험 등록 폼</div>;
+}

--- a/src/app/mypage/experience/components/CategorySelect.stories.tsx
+++ b/src/app/mypage/experience/components/CategorySelect.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import CategorySelect from "./CategorySelect";
+
+const meta: Meta<typeof CategorySelect> = {
+  title: "Components/Common/CategorySelect",
+  component: CategorySelect,
+  tags: ["autodocs"],
+};
+export default meta;
+
+type Story = StoryObj<typeof CategorySelect>;
+
+const SAMPLE_OPTIONS = [
+  { label: "문화 예술", value: "문화 예술" },
+  { label: "식음료", value: "식음료" },
+  { label: "투어", value: "투어" },
+  { label: "관광", value: "관광" },
+  { label: "웰빙", value: "웰빙" },
+];
+
+const SelectExample = () => {
+  const [selected, setSelected] = useState("");
+  return (
+    <div style={{ width: 327 }}>
+      <CategorySelect
+        value={selected}
+        onChange={setSelected}
+        options={SAMPLE_OPTIONS}
+        placeholder="카테고리를 선택하세요"
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <SelectExample />,
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <CategorySelect
+      value=""
+      onChange={() => {}}
+      options={SAMPLE_OPTIONS}
+      disabled
+    />
+  ),
+};

--- a/src/app/mypage/experience/components/CategorySelect.tsx
+++ b/src/app/mypage/experience/components/CategorySelect.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import DownArrow from "@/assets/icon/icon_alt arrow_down.svg";
+import Image from "next/image";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface CategorySelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: Option[];
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export default function CategorySelect({
+  value,
+  onChange,
+  options,
+  disabled = false,
+  placeholder = "선택해주세요",
+}: CategorySelectProps) {
+  return (
+    <div className="relative w-full">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="appearance-none w-full justify-between items-center p-4 gap-3 box-border
+      bg-white border border-gray-100 shadow-[0_2px_6px_rgba(0,0,0,0.02)] rounded-2xl
+      text-gray-400 focus:outline-none "
+      >
+        <option value="">{placeholder}</option>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <Image
+        src={DownArrow}
+        alt="아래화살표"
+        width={24}
+        height={24}
+        className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none"
+      />
+    </div>
+  );
+}

--- a/src/app/mypage/experience/components/ExperienceCard.tsx
+++ b/src/app/mypage/experience/components/ExperienceCard.tsx
@@ -24,7 +24,7 @@ export default function ExperienceCard({
   onDelete,
 }: ExperienceCardProps) {
   return (
-    <div className="flex rounded-3xl bg-white shadow-[0_4px_24px_rgba(156,180,202,0.2)] p-6 max-w-2xl  ">
+    <div className="flex rounded-3xl bg-white shadow-[0_4px_24px_rgba(156,180,202,0.2)] p-6 max-w-2xl mb-6">
       <div className="flex-1 ">
         <h3 className="typo-16-b md:typo-18-b">{title}</h3>
         <div className="flex mt-2 gap-0.5">
@@ -64,7 +64,7 @@ export default function ExperienceCard({
         </div>
       </div>
       {/* 오른쪽 이미지 */}
-      <div className="relative ml-6 w-[82px] h-[82px] md:w-[142px] md:h-[142px]">
+      <div className="relative ml-6 w-[82px] h-[82px]">
         <Image
           src={imageUrl}
           alt={title}

--- a/src/app/mypage/experience/layout.tsx
+++ b/src/app/mypage/experience/layout.tsx
@@ -34,7 +34,7 @@ export default function ExperienceLayout({
                     체험을 등록하거나 수정 및 삭제가 가능합니다.
                   </p>
                 </div>
-                <Link href="/mypage/experience/register">
+                <Link href="/experience-register">
                   <Button label="체험 등록하기" variant="primary" />
                 </Link>
               </header>

--- a/src/app/mypage/experience/layout.tsx
+++ b/src/app/mypage/experience/layout.tsx
@@ -5,7 +5,11 @@ import GNB from "@/components/GNB";
 import Footer from "@/components/Footer";
 import SideMenu from "@/components/SideMenu";
 
-export default function ExperienceLayout() {
+export default function ExperienceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <div>
       {/* TODO: 공용 레이아웃 적용 후 GNB 제거 예정 */}
@@ -23,7 +27,7 @@ export default function ExperienceLayout() {
             {/* RIGHT */}
             <div className="space-y-8">
               {/* 헤더 */}
-              <header className="flex flex-wrap items-center justify-between gap-3">
+              <header className="flex flex-wrap items-center justify-between lg:w-[640px] gap-3">
                 <div>
                   <h1 className="typo-18-b">내 체험 관리</h1>
                   <p className="mt-2 typo-14-m text-gray-500">
@@ -36,7 +40,7 @@ export default function ExperienceLayout() {
               </header>
 
               {/* 카드 리스트 자리 */}
-              <section>{/* TODO: 카드 리스트 */}</section>
+              {children}
             </div>
           </div>
         </div>

--- a/src/app/mypage/experience/mock/experienceMock.ts
+++ b/src/app/mypage/experience/mock/experienceMock.ts
@@ -1,0 +1,72 @@
+export interface Activity {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ExperienceResponse {
+  cursorId: number;
+  totalCount: number;
+  activities: Activity[];
+}
+
+export const experienceMockData: ExperienceResponse = {
+  cursorId: 0,
+  totalCount: 3,
+  activities: [
+    {
+      id: 1,
+      userId: 101,
+      title: "핸드드립 커피 클래스",
+      description:
+        "바리스타에게 직접 배우는 원데이 핸드드립 클래스 ☕️ 원두 선택부터 추출까지 실습 중심으로 진행됩니다.",
+      category: "음식/음료",
+      price: 45000,
+      address: "서울시 마포구 연남동",
+      bannerImageUrl: "",
+      rating: 4.9,
+      reviewCount: 58,
+      createdAt: "2025-10-10T14:00:00.000Z",
+      updatedAt: "2025-10-12T18:30:00.000Z",
+    },
+    {
+      id: 2,
+      userId: 101,
+      title: "캔들 메이킹 클래스",
+      description:
+        "자신만의 향을 담은 소이캔들을 만들어보세요. 향 조합과 디자인을 직접 선택할 수 있습니다.",
+      category: "공예",
+      price: 38000,
+      address: "서울시 성동구 성수동",
+      bannerImageUrl: "",
+      rating: 4.7,
+      reviewCount: 32,
+      createdAt: "2025-10-09T15:00:00.000Z",
+      updatedAt: "2025-10-12T10:00:00.000Z",
+    },
+    {
+      id: 3,
+      userId: 101,
+      title: "플라워 원데이 클래스",
+      description:
+        "계절 꽃으로 부케를 만들어보는 감성 플라워 클래스 🌸 초보자도 쉽게 따라 할 수 있어요.",
+      category: "플라워",
+      price: 55000,
+      address: "서울시 강남구 논현동",
+      bannerImageUrl: "",
+      rating: 4.8,
+      reviewCount: 41,
+      createdAt: "2025-10-08T12:00:00.000Z",
+      updatedAt: "2025-10-13T09:00:00.000Z",
+    },
+  ],
+};

--- a/src/app/mypage/experience/page.tsx
+++ b/src/app/mypage/experience/page.tsx
@@ -1,5 +1,44 @@
 "use client";
 
+import { experienceMockData } from "@/app/mypage/experience/mock/experienceMock";
+import Image from "next/image";
+import emptyState from "@/assets/img/empty_state.png";
+import ExperienceCard from "./components/ExperienceCard";
+
 export default function experiencePage() {
-  return;
+  const activities = experienceMockData.activities;
+
+  if (activities.length === 0) {
+    return (
+      <section className="flex flex-col items-center justify-center text-center py-20">
+        <Image
+          src={emptyState}
+          alt="체험 없음"
+          width={122}
+          height={122}
+          className="mb-4"
+        />
+        <p className="typo-16-m text-gray-600 mb-[30px]">
+          아직 등록한 체험이 없어요
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="lg:w-[640px]">
+      {activities.map((act) => (
+        <ExperienceCard
+          key={act.id}
+          title={act.title}
+          rating={act.rating}
+          reviewCount={act.reviewCount}
+          price={act.price}
+          imageUrl={act.bannerImageUrl}
+          onEdit={() => console.log("수정 클릭:", act.id)}
+          onDelete={() => console.log("삭제 클릭:", act.id)}
+        />
+      ))}
+    </section>
+  );
 }


### PR DESCRIPTION
## 📌 진행사항
- [x] **mock 데이터 구조 정의**
  - `id`, `userId`, `title`, `description`, `category`, `price`, `address`, `bannerImageUrl`, `rating`, `reviewCount`, `createdAt`, `updatedAt`
- [x] **내 체험 관리 페이지 UI 완성**
  -  ExperienceCard 컴포넌트 배치
  - “체험 등록하기” 버튼 → 등록 페이지 라우팅(`/experience-register`)
- [x] `CategorySelect` 컴포넌트 제작
- [x] `experienceMockData` 업데이트 및 `ExperienceCard` 구조 수정 (새 필드 반영)
- [x] 체험 등록/수정 페이지 라우트 추가 및 등록 버튼 라우팅 연결

## 🔧 추후 수정/보완 예정
- API 연결 후 실제 데이터로 교체 필요 
- 에러 처리 및 로딩 상태 UI 개선 예정
- 지금은 빈url , 추후 이미지 url 채울 예정 

## 🖼️ 스크린샷 / 이미지
**[CategorySelect 컴포넌트 제작]**
<img width="422" height="83" alt="image" src="https://github.com/user-attachments/assets/b3d76bb2-3202-4906-b72a-3ae0b6e67270" />

**[내 체험 관리 페이지 UI 배치]**
<img width="1505" height="902" alt="image" src="https://github.com/user-attachments/assets/74268405-e711-479c-ab30-c95ff3d604ab" />

