### PR TITLE
[feature/experience] GNB·Footer 임시 레이아웃 및 내 체험 등록 페이지 UI배치 및 주소 입력 기능 추가

### DIFF
--- a/src/app/experience-register/layout.tsx
+++ b/src/app/experience-register/layout.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import GNB from "@/components/GNB";
+import Footer from "@/components/Footer";
+
+export default function ExperienceRegisterLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      {/* TODO: 공용 레이아웃 적용 후 GNB 제거 예정 */}
+      <GNB isLoggedIn unread={3} />
+      {children}
+      {/* TODO: 공용 레이아웃 적용 후 Footer 제거 예정 */}
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Input from "@/components/Input";
 import CategorySelect from "../mypage/experience/components/CategorySelect";
 import Button from "@/components/Button";
+import AddressInput from "../mypage/experience/components/AddressInput";
 
 export default function ExperienceRegisterPage() {
   const [selected, setSelected] = useState("");
@@ -60,7 +61,7 @@ export default function ExperienceRegisterPage() {
         {/* 주소 */}
         <div className="mb-6">
           <div className="mb-2 typo-16-b text-gray-950">주소</div>
-          <Input placeholder="주소를 입력해 주세요" />
+          <AddressInput />
         </div>
 
         {/* 예약 가능한 시간대 */}

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -1,3 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import Input from "@/components/Input";
+import CategorySelect from "../mypage/experience/components/CategorySelect";
+import Button from "@/components/Button";
+
 export default function ExperienceRegisterPage() {
-  return <div>체험 등록 폼</div>;
+  const [selected, setSelected] = useState("");
+
+  const SAMPLE_OPTIONS = [
+    { label: "문화 예술", value: "문화 예술" },
+    { label: "식음료", value: "식음료" },
+    { label: "투어", value: "투어" },
+    { label: "관광", value: "관광" },
+    { label: "웰빙", value: "웰빙" },
+  ];
+
+  return (
+    <main className="flex justify-center px-6">
+      <div className="w-full max-w-[610px] mt-12">
+        <h3 className="mb-6 typo-18-b">내 체험 등록</h3>
+
+        {/* 제목 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">제목</div>
+          <Input placeholder="제목을 입력해 주세요" />
+        </div>
+
+        {/* 카테고리 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">카테고리</div>
+          <CategorySelect
+            value={selected}
+            onChange={setSelected}
+            options={SAMPLE_OPTIONS}
+            placeholder="카테고리를 선택해 주세요"
+          />
+        </div>
+
+        {/* 설명 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">설명</div>
+          <textarea
+            placeholder="체험에 대한 설명을 입력해 주세요"
+            className="w-full rounded-2xl border border-border-default px-4 py-3
+            typo-14-m text-text-primary placeholder:text-text-secondary/60
+            focus:outline-none focus:ring-2 focus:ring-primary
+            h-[140px] md:h-[200px]
+          "
+          />
+        </div>
+
+        {/* 가격 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">가격</div>
+          <Input placeholder="체험 금액을 입력해 주세요" />
+        </div>
+
+        {/* 주소 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">주소</div>
+          <Input placeholder="주소를 입력해 주세요" />
+        </div>
+
+        {/* 예약 가능한 시간대 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">예약 가능한 시간대</div>
+        </div>
+
+        {/* 배너 이미지 등록 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">배너 이미지 등록</div>
+        </div>
+
+        {/* 소개 이미지 등록 */}
+        <div className="mb-10">
+          <div className="mb-2 typo-16-b text-gray-950">소개 이미지 등록</div>
+        </div>
+        <div className="flex justify-center mb-24">
+          <Button label="등록하기" variant="primary" size="md" />
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/app/mypage/experience/components/AddressInput.tsx
+++ b/src/app/mypage/experience/components/AddressInput.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import Script from "next/script";
+import Input from "@/components/Input";
+
+interface DaumPostcodeData {
+  address: string;
+  addressType: "R" | "J"; // R: 도로명, J: 지번
+  bname: string; // 법정동명
+  buildingName: string; // 건물명
+  zonecode: string; // 우편번호
+  jibunAddress: string; // 지번주소
+  roadAddress: string; // 도로명주소
+  userSelectedType: "R" | "J"; // 사용자가 선택한 주소 타입
+}
+
+export default function AddressInput() {
+  const [address, setAddress] = useState("");
+
+  const openDaumPostcode = () => {
+    // 우편번호 검색 위젯을 생성하는 생성자
+    new window.daum.Postcode({
+      // 사용자가 주소를 선택했을 때 실행되는 콜백함수
+      oncomplete: function (data: DaumPostcodeData) {
+        let fullAddr = data.address; // 주소 변수
+        let extraAddr = ""; // 참고항목 변수
+
+        // 사용자가 선택한 주소 타입에 따라 해당 주소 값을 가져옴.
+        if (data.addressType === "R") {
+          if (data.bname !== "") extraAddr += data.bname;
+          if (data.buildingName !== "")
+            extraAddr +=
+              extraAddr !== "" ? `, ${data.buildingName}` : data.buildingName;
+          fullAddr += extraAddr !== "" ? ` (${extraAddr})` : "";
+        }
+        // 최종 주소 저장
+        setAddress(fullAddr);
+      },
+    }).open();
+  };
+
+  return (
+    <>
+      {/* 다음 우편번호 API 불러오기 */}
+      <Script
+        src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
+        strategy="afterInteractive"
+      />
+
+      {/* 기본 주소 */}
+      <div className="flex gap-2 mb-3">
+        <Input
+          placeholder="주소를 입력해 주세요"
+          value={address}
+          readOnly
+          onClick={openDaumPostcode}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,13 @@
+export {};
+
+declare global {
+  interface Window {
+    daum: {
+      Postcode: new (options: {
+        oncomplete: (data: DaumPostcodeData) => void;
+      }) => {
+        open: () => void;
+      };
+    };
+  }
+}


### PR DESCRIPTION
### 📌 PR 내용 요약

* GNB, Footer 임시 레이아웃 구성
* 내 체험 등록 페이지 UI 기본 배치 (/experience-register)
* 다음 우편번호 API 연동을 통한 주소 입력 기능 구현

### ✅ 진행 상태

* [x] 기능 구현 완료
* [ ] API 연동 후 실제 데이터 교체

### 🔧 추후 작업

* 예약 가능한 시간대 컴포넌트 제작
* 배너 이미지 등록 컴포넌트 제작
* 내 체험 등록 UI 배치 추가 작업
* API 연결 후 실제 데이터로 교체

### 🖼️ 스크린샷
**[내 체험 등록 UI 배치]**
<img width="1416" height="917" alt="image" src="https://github.com/user-attachments/assets/39531423-9fe4-4f5b-8919-1156d309e000" />

**[다음 우편번호 API 연동]**
<img width="1536" height="782" alt="image" src="https://github.com/user-attachments/assets/447174ed-9a82-4186-ba92-04be0c821c4c" />

