### PR TITLE
[feature/experience] 내 체험 등록 페이지 PhotoSection / DateSection 기능 추가 및 ImageUpload 리팩토링

### DIFF
--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -6,6 +6,7 @@ import CategorySelect from "@/app/mypage/experience/components/CategorySelect";
 import Button from "@/components/Button";
 import AddressInput from "@/app/mypage/experience/components/AddressInput";
 import DateSection from "../mypage/experience/components/DateSection";
+import PhotoSection from "../mypage/experience/components/PhotoSection";
 
 export default function ExperienceRegisterPage() {
   const [selected, setSelected] = useState("");
@@ -73,11 +74,13 @@ export default function ExperienceRegisterPage() {
         {/* 배너 이미지 등록 */}
         <div className="mb-6">
           <div className="mb-2 typo-16-b text-gray-950">배너 이미지 등록</div>
+          <PhotoSection limit={1} />
         </div>
 
         {/* 소개 이미지 등록 */}
         <div className="mb-10">
           <div className="mb-2 typo-16-b text-gray-950">소개 이미지 등록</div>
+          <PhotoSection limit={4} />
         </div>
         <div className="flex justify-center mb-24">
           <Button label="등록하기" variant="primary" size="md" />

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import Input from "@/components/Input";
-import CategorySelect from "../mypage/experience/components/CategorySelect";
+import CategorySelect from "@/app/mypage/experience/components/CategorySelect";
 import Button from "@/components/Button";
-import AddressInput from "../mypage/experience/components/AddressInput";
+import AddressInput from "@/app/mypage/experience/components/AddressInput";
+import DateSection from "../mypage/experience/components/DateSection";
 
 export default function ExperienceRegisterPage() {
   const [selected, setSelected] = useState("");
@@ -19,7 +20,7 @@ export default function ExperienceRegisterPage() {
 
   return (
     <main className="flex justify-center px-6">
-      <div className="w-full max-w-[610px] mt-12">
+      <div className="w-full max-w-[700px] mt-12">
         <h3 className="mb-6 typo-18-b">내 체험 등록</h3>
 
         {/* 제목 */}
@@ -66,7 +67,7 @@ export default function ExperienceRegisterPage() {
 
         {/* 예약 가능한 시간대 */}
         <div className="mb-6">
-          <div className="mb-2 typo-16-b text-gray-950">예약 가능한 시간대</div>
+          <DateSection />
         </div>
 
         {/* 배너 이미지 등록 */}

--- a/src/app/mypage/experience/components/DateInput.tsx
+++ b/src/app/mypage/experience/components/DateInput.tsx
@@ -20,7 +20,7 @@ export default function DateInput({ value, onChange }: DateInputProps) {
 
   return (
     <div
-      className="relative flex justify-between items-center  w-[327px] sm:w-[344px] md:w-[360px] h-[54px] px-5 py-4 gap-[10px]
+      className="relative flex justify-between items-center  w-full sm:w-[344px] md:w-[360px] h-[54px] px-5 py-4 gap-[10px]
       bg-white border border-gray-100 shadow-[0_2px_6px_rgba(0,0,0,0.02)] rounded-2xl
       box-border"
     >

--- a/src/app/mypage/experience/components/DateSection.stories.tsx
+++ b/src/app/mypage/experience/components/DateSection.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import DateSection from "./DateSection";
+
+const meta: Meta<typeof DateSection> = {
+  title: "Experience/DateSection",
+  component: DateSection,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DateSection>;
+
+export const Default: Story = {};

--- a/src/app/mypage/experience/components/DateSection.tsx
+++ b/src/app/mypage/experience/components/DateSection.tsx
@@ -35,7 +35,11 @@ export default function DateSection() {
     setSlots((prev) => prev.filter((slot) => slot.id !== id));
   };
 
-  const handleChange = (id: number, key: keyof TimeSlot, value: any) => {
+  const handleChange = <K extends keyof TimeSlot>(
+    id: number,
+    key: K,
+    value: TimeSlot[K],
+  ) => {
     setSlots((prev) =>
       prev.map((slot) => (slot.id === id ? { ...slot, [key]: value } : slot)),
     );

--- a/src/app/mypage/experience/components/DateSection.tsx
+++ b/src/app/mypage/experience/components/DateSection.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import DateInput from "./DateInput";
+import CategorySelect from "./CategorySelect";
+import IconPlus from "@/assets/icon/icon_plus_button.svg";
+import IconMinus from "@/assets/icon/icon_minus_button.svg";
+
+interface TimeSlot {
+  id: number;
+  date: Date | null;
+  start: string;
+  end: string;
+}
+
+export default function DateSection() {
+  const [slots, setSlots] = useState<TimeSlot[]>([
+    { id: Date.now(), date: null, start: "", end: "" },
+  ]);
+
+  const timeOptions = Array.from({ length: 24 }, (_, i) => {
+    const label = `${i.toString().padStart(2, "0")}:00`;
+    return { label, value: label };
+  });
+
+  const handleAdd = () => {
+    setSlots((prev) => [
+      ...prev,
+      { id: Date.now() + Math.random(), date: null, start: "", end: "" },
+    ]);
+  };
+
+  const handleRemove = (id: number) => {
+    setSlots((prev) => prev.filter((slot) => slot.id !== id));
+  };
+
+  const handleChange = (id: number, key: keyof TimeSlot, value: any) => {
+    setSlots((prev) =>
+      prev.map((slot) => (slot.id === id ? { ...slot, [key]: value } : slot)),
+    );
+  };
+
+  return (
+    <section className="flex flex-col w-full max-w-[700px] gap-5 md:gap-6">
+      {/* 제목 */}
+      <h3 className="typo-16-b text-gray-950">예약 가능한 시간대</h3>
+
+      {/* 헤더 */}
+      <div className="hidden sm:flex w-[700px] justify-between text-gray-950 px-1">
+        <span className="flex-1 typo-16-m">날짜</span>
+        <span className="w-[160px] text-center typo-16-m">시작 시간</span>
+        <span className="w-[160px] text-center typo-16-m">종료 시간</span>
+        <span className="w-10" />
+      </div>
+
+      {/* 첫 줄 (+버튼 있는 줄) */}
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+          <div className="flex-1 w-full  ">
+            <DateInput
+              value={slots[0].date}
+              onChange={(d) => handleChange(slots[0].id, "date", d)}
+            />
+          </div>
+
+          <div className="flex flex-row items-center gap-3 sm:gap-2 w-full sm:w-[340px]">
+            <div className="flex-1 min-w-[120px]">
+              <CategorySelect
+                value={slots[0].start}
+                onChange={(v) => handleChange(slots[0].id, "start", v)}
+                options={timeOptions}
+                placeholder="00:00"
+              />
+            </div>
+
+            <span className=" text-gray-500">-</span>
+
+            <div className="flex-1 min-w-[120px]">
+              <CategorySelect
+                value={slots[0].end}
+                onChange={(v) => handleChange(slots[0].id, "end", v)}
+                options={timeOptions}
+                placeholder="00:00"
+              />
+            </div>
+
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="shrink-0 flex items-center justify-center w-[42px] h-[42px] bg-primary rounded-full sm:ml-2 hover:brightness-110 transition"
+            >
+              <Image src={IconPlus} alt="추가" width={24} height={24} />
+            </button>
+          </div>
+        </div>
+
+        {/* 고정 구분선 */}
+        <hr className="border-t border-gray-200 mt-2" />
+      </div>
+
+      {/* 이후 줄들 */}
+      <div className="flex flex-col gap-4">
+        {slots.slice(1).map((slot) => (
+          <div
+            key={slot.id}
+            className="flex flex-col sm:flex-row sm:items-center gap-3"
+          >
+            <div className="flex-1 w-full">
+              <DateInput
+                value={slot.date}
+                onChange={(d) => handleChange(slot.id, "date", d)}
+              />
+            </div>
+
+            <div className="flex flex-row items-center gap-3 sm:gap-2 w-full sm:w-[340px]">
+              <div className="flex-1 min-w-[120px]">
+                <CategorySelect
+                  value={slot.start}
+                  onChange={(v) => handleChange(slot.id, "start", v)}
+                  options={timeOptions}
+                  placeholder="00:00"
+                />
+              </div>
+
+              <span className="  text-gray-500">-</span>
+
+              <div className="flex-1 min-w-[120px]">
+                <CategorySelect
+                  value={slot.end}
+                  onChange={(v) => handleChange(slot.id, "end", v)}
+                  options={timeOptions}
+                  placeholder="00:00"
+                />
+              </div>
+
+              <button
+                type="button"
+                onClick={() => handleRemove(slot.id)}
+                className="shrink-0 flex items-center justify-center w-[42px] h-[42px] bg-gray-50 rounded-full sm:ml-2 hover:bg-gray-100 transition"
+              >
+                <Image src={IconMinus} alt="삭제" width={24} height={24} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/mypage/experience/components/ImageUpload.stories.tsx
+++ b/src/app/mypage/experience/components/ImageUpload.stories.tsx
@@ -10,16 +10,34 @@ const meta: Meta<typeof ImageUpload> = {
 export default meta;
 type Story = StoryObj<typeof ImageUpload>;
 
-export const SingleImage: Story = {
+export const Default: Story = {
   args: {
-    limit: 1,
-    onChange: (files) => console.log("Single image:", files),
+    limit: 4,
+    count: 0,
+    onChange: (files) => console.log("업로드된 파일:", files),
   },
 };
 
-export const MultiImage: Story = {
+export const SingleUploaded: Story = {
   args: {
     limit: 4,
-    onChange: (files) => console.log("Multi images:", files),
+    count: 1,
+    onChange: (files) => console.log("1개 업로드:", files),
+  },
+};
+
+export const FullUploaded: Story = {
+  args: {
+    limit: 4,
+    count: 4,
+    onChange: (files) => console.log("모두 업로드됨:", files),
+  },
+};
+
+export const OneOfOne: Story = {
+  args: {
+    limit: 1,
+    count: 0,
+    onChange: (files) => console.log("1개 제한 업로드:", files),
   },
 };

--- a/src/app/mypage/experience/components/ImageUpload.tsx
+++ b/src/app/mypage/experience/components/ImageUpload.tsx
@@ -6,33 +6,49 @@ import IconEyeOff from "@/assets/icon/icon_eye_off.svg";
 interface ImageUploadProps {
   onChange: (files: File[]) => void;
   limit?: number;
+  count?: number;
+  disabled?: boolean;
 }
 
-export default function ImageUpload({ onChange, limit = 4 }: ImageUploadProps) {
+export default function ImageUpload({
+  onChange,
+  limit = 4,
+  count = 0,
+  disabled = false,
+}: ImageUploadProps) {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files || []).slice(0, limit);
+    if (disabled) return;
+    const files = Array.from(e.target.files || []).slice(0, limit - count);
     onChange(files);
   };
 
   return (
     <label
-      className="flex flex-col justify-center items-center w-32 h-32 p-4 gap-3
-    bg-white border border-gray-100 rounded-2xl box-border
-      shadow-[0_2px_6px_rgba(0,0,0,0.02)]
-      cursor-pointer"
+      className={`flex flex-col justify-center items-center w-32 h-32 p-4 gap-3
+        bg-white border border-gray-100 rounded-2xl box-border
+        shadow-[0_2px_6px_rgba(0,0,0,0.02)]
+        transition cursor-pointer
+        ${
+          disabled
+            ? "opacity-40 cursor-not-allowed"
+            : "hover:border-primary hover:shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+        }`}
     >
       <input
         type="file"
         accept="image/*"
-        multiple={limit > 1}
+        multiple={!disabled && limit > 1}
         className="hidden"
         onChange={handleFileChange}
+        disabled={disabled}
       />
 
       <div>
         <Image src={IconEyeOff} alt="icon_eye_off" width={40} height={40} />
       </div>
-      <span className="typo-14-m text-gray-600">0/{limit}</span>
+      <span className="typo-14-m text-gray-600">
+        {count}/{limit}
+      </span>
     </label>
   );
 }

--- a/src/app/mypage/experience/components/PhotoSection.tsx
+++ b/src/app/mypage/experience/components/PhotoSection.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import ImageUpload from "./ImageUpload";
+import Image from "next/image";
+import IconDelete from "@/assets/icon/icon_delete_button.svg";
+
+interface PhotoSectionProps {
+  /** 업로드 제한 개수 (ex. 1 → 배너용, 4 → 소개용) */
+  limit?: number;
+}
+
+export default function PhotoSection({ limit = 4 }: PhotoSectionProps) {
+  const [images, setImages] = useState<File[]>([]);
+
+  const handleUpload = (newFiles: File[]) => {
+    if (images.length >= limit) return; // 추가 차단
+
+    const combined = [...images, ...newFiles].slice(0, limit);
+    setImages(combined);
+  };
+
+  const handleRemove = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div
+      className={`flex flex-wrap justify-center sm:justify-start gap-3 ${
+        limit === 1 ? "flex-row" : "flex-row sm:flex-row"
+      }`}
+    >
+      {/* 업로드 박스 (항상 존재) */}
+      <ImageUpload
+        onChange={handleUpload}
+        limit={limit}
+        count={images.length}
+        disabled={images.length >= limit} // limit 도달 시 비활성화
+      />
+      {/* 업로드된 이미지 썸네일 */}
+      {images.map((file, idx) => {
+        const preview = URL.createObjectURL(file);
+        return (
+          <div className="relative">
+            <div
+              key={idx}
+              className="relative w-32 h-32 rounded-2xl overflow-hidden 
+              shadow-[0_2px_6px_rgba(0,0,0,0.02)] border border-gray-100 border-solid"
+            >
+              <Image
+                src={preview}
+                alt={`uploaded-${idx}`}
+                fill
+                className="object-cover "
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => handleRemove(idx)}
+              className="absolute  top-[-8px] right-[-8px] w-7 h-7 flex items-center justify-center 
+                bg-gray-950 rounded-full hover:brightness-110 transition  "
+            >
+              <Image src={IconDelete} alt="삭제" width={20} height={20} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/mypage/experience/mock/experienceMock.ts
+++ b/src/app/mypage/experience/mock/experienceMock.ts
@@ -1,3 +1,5 @@
+import streetdanceImg from "@/assets/img/streetdance_main.png";
+
 export interface Activity {
   id: number;
   userId: number;
@@ -32,7 +34,7 @@ export const experienceMockData: ExperienceResponse = {
       category: "음식/음료",
       price: 45000,
       address: "서울시 마포구 연남동",
-      bannerImageUrl: "",
+      bannerImageUrl: streetdanceImg.src,
       rating: 4.9,
       reviewCount: 58,
       createdAt: "2025-10-10T14:00:00.000Z",
@@ -47,7 +49,7 @@ export const experienceMockData: ExperienceResponse = {
       category: "공예",
       price: 38000,
       address: "서울시 성동구 성수동",
-      bannerImageUrl: "",
+      bannerImageUrl: streetdanceImg.src,
       rating: 4.7,
       reviewCount: 32,
       createdAt: "2025-10-09T15:00:00.000Z",
@@ -62,7 +64,7 @@ export const experienceMockData: ExperienceResponse = {
       category: "플라워",
       price: 55000,
       address: "서울시 강남구 논현동",
-      bannerImageUrl: "",
+      bannerImageUrl: streetdanceImg.src,
       rating: 4.8,
       reviewCount: 41,
       createdAt: "2025-10-08T12:00:00.000Z",


### PR DESCRIPTION
## 📌 진행사항

### ⏰ DateSection
- 예약 가능한 시간대 추가 / 삭제 기능 구현
- `DateInput`, `CategorySelect` 조합으로 날짜·시간 선택 지원
- 타입 안정화 (`any` 제거, 제네릭 적용)
- 반응형 UI 적용 및 스타일 정리

### 🖼️ PhotoSection
- 모바일 환경에서 이미지 업로드 박스 중앙 정렬
- 업로드한 이미지 썸네일 및 삭제 버튼 오버레이 처리
- 업로드 제한(`limit`) 초과 시 `disabled` 상태 전환
- `overflow-hidden`으로 삭제 버튼 잘리는 문제 해결

### 📤 ImageUpload
- `PhotoSection` 대응을 위한 구조 리팩토링
- `limit`, `count`, `disabled` props 로직 추가
- 다중 업로드 시 초과 파일 제한 적용
- 비활성화 시 hover 효과 제거 및 투명도 적용


### 🧩 페이지 통합
- `experience-register` 페이지에 `PhotoSection`, `DateSection` 통합 적용

---

## 🔧 추후 수정 / 보완 예정
- [ ] API 연동 후 실제 서버 업로드 로직 교체

---

## 🖼️ 스크린샷 / 이미지
**[DateSection 컴포넌트]**
<img width="897" height="397" alt="image" src="https://github.com/user-attachments/assets/fe068572-726d-4d6c-ab9c-7df27fdd3244" />

**[PhotoSection 컴포넌트]**
**- 데스크탑 및 태블릿.ver**
<img width="1012" height="462" alt="image" src="https://github.com/user-attachments/assets/77f7b00f-f36e-4eb6-9e6c-0869f653fa2b" />
**- 모바일.ver (가운데 정렬)** 
<img width="341" height="618" alt="image" src="https://github.com/user-attachments/assets/732e57a8-32ff-448f-a273-62d11cfcaac3" />

**[내 체험 등록 페이지 (/experience-register)]**
<img width="825" height="902" alt="image" src="https://github.com/user-attachments/assets/887568ad-5334-437a-a1b6-36578f54276d" />

