### PR TITLE
[feature/experience] 내 체험 삭제/ 수정 기능(mock 기반) 로직 추가

### DIFF
--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -39,6 +39,13 @@ const mockActivities = [
   },
 ];
 
+interface MyActivitiesResponse {
+  activities: {
+    id: number;
+    [key: string]: unknown;
+  }[];
+}
+
 export default function ExperienceEditPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -70,16 +77,18 @@ export default function ExperienceEditPage() {
     },
     onSuccess: (updated) => {
       // 캐시 즉시 수정
-      queryClient.setQueryData(["myActivities"], (oldData: any) => {
-        if (!oldData) return oldData;
-        return {
-          ...oldData,
-          activities: oldData.activities.map((a: any) =>
-            a.id === updated.id ? updated : a,
-          ),
-        };
-      });
-
+      queryClient.setQueryData<MyActivitiesResponse | undefined>(
+        ["myActivities"],
+        (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            activities: oldData.activities.map((a) =>
+              a.id === updated.id ? { ...a, ...updated } : a,
+            ),
+          };
+        },
+      );
       // 서버 데이터 다시 불러오기
       queryClient.invalidateQueries({ queryKey: ["myActivities"] });
       queryClient.invalidateQueries({ queryKey: ["activityDetail", id] });

--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -1,3 +1,243 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import Modal from "@/components/Modal";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import CategorySelect from "@/app/mypage/experience/components/CategorySelect";
+import AddressInput from "@/app/mypage/experience/components/AddressInput";
+import DateSection from "@/app/mypage/experience/components/DateSection";
+import PhotoSection from "@/app/mypage/experience/components/PhotoSection";
+import { CreateActivityRequest } from "@/types/experience";
+// testImg 나중에 인증 권한 해결 후 지울 예정
+import streetdanceImg from "@/assets/img/streetdance_main.png";
+
+const mockActivities = [
+  {
+    id: 1,
+    title: "트로피컬 피싱 투어",
+    category: "투어",
+    description: "시원한 바다에서 낚시 체험!",
+    address: "제주도 바다",
+    price: 89000,
+    bannerImageUrl: streetdanceImg.src,
+    subImageUrls: [],
+    schedules: [{ date: "2025-10-25", startTime: "09:00", endTime: "12:00" }],
+  },
+  {
+    id: 2,
+    title: "스트릿 댄스 클래스",
+    category: "문화 예술",
+    description: "현직 댄서에게 배우는 스트릿 댄스!",
+    address: "홍대",
+    price: 65000,
+    bannerImageUrl: streetdanceImg.src,
+    subImageUrls: [],
+    schedules: [{ date: "2025-10-30", startTime: "15:00", endTime: "17:00" }],
+  },
+];
+
 export default function ExperienceEditPage() {
-  return <div>체험 수정 폼</div>;
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { id } = useParams();
+  const [form, setForm] = useState<CreateActivityRequest | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 기존 체험 데이터 불러오기 (지금은 mock, 나중엔 getActivityDetail로 교체)
+  const { data, isLoading } = useQuery({
+    queryKey: ["activityDetail", id],
+    queryFn: async () => {
+      const target = mockActivities.find((a) => a.id === Number(id));
+      return target!;
+      // 나중엔 아래처럼 교체하면 됨:
+      // return getActivityDetail(Number(id));
+    },
+  });
+
+  useEffect(() => {
+    if (data) setForm(data);
+  }, [data]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload: CreateActivityRequest) => {
+      // 나중엔 아래로 교체
+      // return updateActivity(Number(id), payload);
+      console.log("mock update", payload);
+      return { ...payload, id: Number(id) };
+    },
+    onSuccess: (updated) => {
+      // 캐시 즉시 수정
+      queryClient.setQueryData(["myActivities"], (oldData: any) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          activities: oldData.activities.map((a: any) =>
+            a.id === updated.id ? updated : a,
+          ),
+        };
+      });
+
+      // 서버 데이터 다시 불러오기
+      queryClient.invalidateQueries({ queryKey: ["myActivities"] });
+      queryClient.invalidateQueries({ queryKey: ["activityDetail", id] });
+
+      setIsModalOpen(true);
+    },
+  });
+
+  const handleChange = (
+    key: keyof CreateActivityRequest,
+    value: string | number | string[] | CreateActivityRequest["schedules"],
+  ) => {
+    if (!form) return;
+    setForm((prev) => ({ ...prev!, [key]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (!form) return;
+    if (
+      !form.title ||
+      !form.category ||
+      !form.description ||
+      !form.price ||
+      !form.address ||
+      !form.schedules.length ||
+      !form.bannerImageUrl
+    ) {
+      alert("필수 항목을 입력해 주세요.");
+      return;
+    }
+    mutation.mutate(form);
+  };
+
+  const handleModalConfirm = () => {
+    setIsModalOpen(false);
+    router.push("/mypage/experience");
+  };
+
+  const SAMPLE_OPTIONS = [
+    { label: "문화 예술", value: "문화 예술" },
+    { label: "식음료", value: "식음료" },
+    { label: "투어", value: "투어" },
+    { label: "관광", value: "관광" },
+    { label: "웰빙", value: "웰빙" },
+  ];
+
+  if (isLoading || !form) return <p>로딩 중...</p>;
+
+  return (
+    <main className="flex justify-center px-6">
+      <div className="w-full max-w-[700px] mt-12">
+        <h3 className="mb-6 typo-18-b">내 체험 등록</h3>
+
+        {/* 제목 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">제목</div>
+          <Input
+            value={form.title}
+            placeholder="제목을 입력해 주세요"
+            onChange={(e) => handleChange("title", e.target.value)}
+          />
+        </div>
+
+        {/* 카테고리 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">카테고리</div>
+          <CategorySelect
+            value={form.category}
+            onChange={(v) => handleChange("category", v)}
+            options={SAMPLE_OPTIONS}
+            placeholder="카테고리를 선택해 주세요"
+          />
+        </div>
+
+        {/* 설명 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">설명</div>
+          <textarea
+            value={form.description}
+            onChange={(e) => handleChange("description", e.target.value)}
+            placeholder="체험에 대한 설명을 입력해 주세요"
+            className="w-full rounded-2xl border border-border-default px-4 py-3
+              typo-14-m text-text-primary placeholder:text-text-secondary/60
+              focus:outline-none focus:ring-2 focus:ring-primary
+              h-[140px] md:h-[200px]"
+          />
+        </div>
+
+        {/* 가격 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">가격</div>
+          <Input
+            value={form.price}
+            placeholder="체험 금액을 입력해 주세요"
+            onChange={(e) => handleChange("price", Number(e.target.value))}
+          />
+        </div>
+
+        {/* 주소 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">주소</div>
+          <AddressInput
+            value={form.address}
+            onChange={(v) => handleChange("address", v)}
+          />
+        </div>
+
+        {/* 예약 가능한 시간대 */}
+        <div className="mb-6">
+          <DateSection
+            value={form.schedules}
+            onChange={(schedules) => handleChange("schedules", schedules)}
+          />
+        </div>
+
+        {/* 배너 이미지 등록 */}
+        <div className="mb-6">
+          <div className="mb-2 typo-16-b text-gray-950">배너 이미지 등록</div>
+          <PhotoSection
+            limit={1}
+            value={form.bannerImageUrl ? [form.bannerImageUrl] : []}
+            onChange={(urls) => handleChange("bannerImageUrl", urls[0] ?? "")}
+          />
+        </div>
+
+        {/* 소개 이미지 등록 */}
+        <div className="mb-10">
+          <div className="mb-2 typo-16-b text-gray-950">소개 이미지 등록</div>
+          <PhotoSection
+            limit={4}
+            value={form.subImageUrls}
+            onChange={(urls) => handleChange("subImageUrls", urls)}
+          />
+        </div>
+
+        <div className="flex justify-center mb-24">
+          <Button
+            label={mutation.isPending ? "수정 중..." : "수정하기"}
+            variant="primary"
+            size="md"
+            onClick={handleSubmit}
+            disabled={mutation.isPending}
+          />
+        </div>
+
+        {/* 수정 완료 모달 */}
+        <Modal
+          open={isModalOpen}
+          title=" "
+          confirmText="확인"
+          cancelText=""
+          onConfirm={handleModalConfirm}
+          onClose={handleModalConfirm}
+          widthClass="max-w-sm"
+        >
+          <p>수정이 완료되었습니다.</p>
+        </Modal>
+      </div>
+    </main>
+  );
 }

--- a/src/app/mypage/experience/page.tsx
+++ b/src/app/mypage/experience/page.tsx
@@ -5,7 +5,7 @@ import emptyState from "@/assets/img/empty_state.png";
 import ExperienceCard from "./components/ExperienceCard";
 import Modal from "@/components/Modal";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import warning from "@/assets/img/warning_state.png";
 // testImg 나중에 인증 권한 해결 후 지울 예정
 import streetdanceImg from "@/assets/img/streetdance_main.png";
@@ -47,16 +47,47 @@ export default function ExperiencePage() {
   // --------------------------
   // React Query (현재는 mock으로 대체)
   // --------------------------
+  const queryClient = useQueryClient();
+
   const {
     data = mockData,
     isLoading,
     isError,
   } = useQuery({
     queryKey: ["myActivities"],
+    // 나중에 백엔드 API 연결되면 아래 한 줄로 교체
+    // queryFn: getMyActivities,
     queryFn: async () => mockData, // getMyActivities 대신 mock으로
   });
 
   const activities = data.activities || [];
+
+  // --------------------------
+  // 삭제 Mutation (mock 기반)
+  // --------------------------
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      // 나중엔 여기가 실제 API 호출로 교체됨
+      // await deleteActivity(id); // <= 서버 요청
+      // mock이라 바로 반환
+      return id;
+    },
+    onSuccess: (id) => {
+      // 1️⃣ 먼저 캐시 즉시 수정 (UI 반영 빠르게)
+      queryClient.setQueryData(["myActivities"], (oldData: typeof mockData) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          activities: oldData.activities.filter((a) => a.id !== id),
+        };
+      });
+      // 2️⃣ 그 다음에 서버 데이터 다시 불러오도록 invalidation
+      //queryClient.invalidateQueries({ queryKey: ["myActivities"] });
+
+      setDeleteModalOpen(false);
+      setSelectedActivity(null);
+    },
+  });
 
   // --------------------------
   // 핸들러
@@ -67,9 +98,8 @@ export default function ExperiencePage() {
   };
 
   const handleConfirmDelete = () => {
-    console.log("삭제 확정:", selectedActivity?.id);
-    // TODO: 삭제 API 연결 예정
-    setDeleteModalOpen(false);
+    if (!selectedActivity) return;
+    deleteMutation.mutate(selectedActivity.id);
   };
 
   // --------------------------

--- a/src/app/mypage/experience/page.tsx
+++ b/src/app/mypage/experience/page.tsx
@@ -5,12 +5,14 @@ import emptyState from "@/assets/img/empty_state.png";
 import ExperienceCard from "./components/ExperienceCard";
 import Modal from "@/components/Modal";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import warning from "@/assets/img/warning_state.png";
 // testImg 나중에 인증 권한 해결 후 지울 예정
 import streetdanceImg from "@/assets/img/streetdance_main.png";
 
 export default function ExperiencePage() {
+  const router = useRouter();
   // --------------------------
   // 모달 상태 관리
   // --------------------------
@@ -102,6 +104,10 @@ export default function ExperiencePage() {
     deleteMutation.mutate(selectedActivity.id);
   };
 
+  const handleEditClick = (id: number) => {
+    router.push(`/experience-edit/${id}`); // 수정 페이지로 이동
+  };
+
   // --------------------------
   // 상태별 렌더링
   // --------------------------
@@ -151,7 +157,7 @@ export default function ExperiencePage() {
           reviewCount={act.reviewCount}
           price={Number(act.price)}
           imageUrl={act.bannerImageUrl}
-          onEdit={() => console.log("수정 클릭:", act.id)}
+          onEdit={() => handleEditClick(act.id)}
           onDelete={() => handleDeleteClick(act)}
         />
       ))}


### PR DESCRIPTION

<h2>📌 진행사항</h2>
<ul>
<li>내 체험 <strong>삭제 / 수정 기능(mock 기반)</strong> 추가</li>
<li>React Query(<code>useQuery</code>, <code>useMutation</code>, <code>useQueryClient</code>) 구조로 데이터 상태 관리</li>
<li><strong>삭제 기능</strong>
<ul>
<li><code>useMutation</code> + <code>queryClient.setQueryData()</code>로 즉시 UI 반영</li>
<li>삭제 확인 모달(<code>Modal</code>) 연결 및 사용자 피드백 처리</li>
<li>나중에 <code>invalidateQueries()</code>로 서버 동기화 예정</li>
</ul>
</li>
<li><strong>수정 기능</strong>
<ul>
<li><code>mockActivities</code>에서 ID 매칭해 데이터 불러오기(<code>useQuery</code>)</li>
<li>수정 시 <code>useMutation</code>으로 mock 업데이트 및 캐시 갱신</li>
<li>수정 완료 시 모달 출력 후 <code>/mypage/experience</code>로 이동</li>
</ul>
</li>
<li><strong>수정하기 버튼 라우팅 연결</strong>
<ul>
<li>체험 카드의 “수정하기” 버튼 클릭 시 <code>/experience-edit/[id]</code> 페이지로 이동</li>
</ul>
</li>
</ul>
<h2>🔧 추후 수정/보완 예정</h2>
<ul>
<li>실제 API(<code>getMyActivities</code>, <code>deleteActivity</code>, <code>getActivityDetail</code>, <code>updateActivity</code>) 연동 예정</li>
</ul>
<h2>🖼️ 스크린샷/이미지</h2>

**[내 체험 수정]**
<img width="990" height="1021" alt="image" src="https://github.com/user-attachments/assets/74aed590-dff1-4b89-9014-473eec47cd3e" />

**[내 체험 삭제]**
<img width="622" height="455" alt="image" src="https://github.com/user-attachments/assets/1a1473cb-e47b-4a91-aafd-931f7ff44cb2" />


