### PR TITLE
[feature/experience] 내 체험 수정 페이지 이탈 모달 연결 및 뒤로가기 이동 문제 수정

### DIFF
--- a/src/app/experience-edit/[id]/layout.tsx
+++ b/src/app/experience-edit/[id]/layout.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import GNB from "@/components/GNB";
+import Footer from "@/components/Footer";
+
+export default function ExperienceRegisterLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <GNB isLoggedIn unread={3} />
+      {children}
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -13,6 +13,8 @@ import PhotoSection from "@/app/mypage/experience/components/PhotoSection";
 import { CreateActivityRequest } from "@/types/experience";
 // testImg 나중에 인증 권한 해결 후 지울 예정
 import streetdanceImg from "@/assets/img/streetdance_main.png";
+import Image from "next/image";
+import warning from "@/assets/img/warning_state.png";
 
 const mockActivities: (CreateActivityRequest & { id: number })[] = [
   {
@@ -53,6 +55,9 @@ export default function ExperienceEditPage() {
   const id = Number(params.id);
   const [form, setForm] = useState<CreateActivityRequest | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false); // 이탈 모달
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null); // 이동하려던 URL
+  const [isDirty, setIsDirty] = useState(false); // 폼 변경 여부
 
   // 기존 체험 데이터 불러오기 (지금은 mock, 나중엔 getActivityDetail로 교체)
   const { data, isLoading } = useQuery({
@@ -102,6 +107,7 @@ export default function ExperienceEditPage() {
       queryClient.invalidateQueries({ queryKey: ["activityDetail", id] });
 
       setIsModalOpen(true);
+      setIsDirty(false);
     },
   });
 
@@ -110,6 +116,7 @@ export default function ExperienceEditPage() {
     value: string | number | string[] | CreateActivityRequest["schedules"],
   ) => {
     if (!form) return;
+    setIsDirty(true); // 수정 중 플래그 추가
     setForm((prev) => ({ ...prev!, [key]: value }));
   };
 
@@ -127,12 +134,74 @@ export default function ExperienceEditPage() {
       alert("필수 항목을 입력해 주세요.");
       return;
     }
+    setIsDirty(false); // 수정 버튼 클릭 시 이탈로 인식하지 않도록
     mutation.mutate(form);
   };
 
   const handleModalConfirm = () => {
     setIsModalOpen(false);
-    router.push("/mypage/experience");
+    safePush("/mypage/experience");
+  };
+
+  // 커스텀 push
+  const safePush = (url: string) => {
+    if (isDirty) {
+      setPendingUrl(url);
+      setIsLeaveModalOpen(true);
+    } else {
+      router.push(url);
+    }
+  };
+
+  // 페이지 이탈 감지
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const handlePopState = (e: PopStateEvent) => {
+      e.preventDefault();
+      setPendingUrl("/mypage/experience"); // 명시적으로 뒤로가기 시 이동할 경로 지정
+      setIsLeaveModalOpen(true);
+    };
+
+    const handleLinkClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest("a") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (
+        !href ||
+        href.startsWith("#") ||
+        href.startsWith("mailto:") ||
+        href.startsWith("tel:")
+      )
+        return;
+
+      e.preventDefault();
+      setPendingUrl(href);
+      setIsLeaveModalOpen(true);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    document.addEventListener("click", handleLinkClick, true);
+    history.pushState(null, "", window.location.href);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+      document.removeEventListener("click", handleLinkClick);
+    };
+  }, [isDirty]);
+
+  //  “예” → 이동하려던 페이지로
+  const handleLeaveConfirm = () => {
+    setIsLeaveModalOpen(false);
+    const targetUrl = pendingUrl || "/mypage/experience";
+    router.push(targetUrl);
+  };
+
+  // “아니오” → 현재 페이지 유지
+  const handleLeaveCancel = () => {
+    setPendingUrl(null);
+    setIsLeaveModalOpen(false);
   };
 
   const SAMPLE_OPTIONS = [
@@ -252,6 +321,30 @@ export default function ExperienceEditPage() {
           onClose={handleModalConfirm}
         >
           <p>수정이 완료되었습니다.</p>
+        </Modal>
+
+        {/* 이탈 확인 모달 추가 */}
+        <Modal
+          open={isLeaveModalOpen}
+          title=""
+          confirmText="예"
+          cancelText="아니오"
+          onConfirm={handleLeaveConfirm}
+          onClose={handleLeaveCancel}
+        >
+          <div className="text-center">
+            <Image
+              src={warning}
+              alt="경고"
+              width={80}
+              height={80}
+              className="mx-auto mb-4"
+            />
+            <p className="text-gray-950">
+              저장되지 않았습니다. <br />
+              정말 페이지를 벗어나시겠습니까?
+            </p>
+          </div>
         </Modal>
       </div>
     </main>

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -98,10 +98,10 @@ export default function ExperienceRegisterPage() {
     if (!isDirty) return;
 
     // 브라우저 뒤로가기 감지
-    const handlePopState = () => {
-      setPendingUrl(document.referrer || "/");
+    const handlePopState = (e: PopStateEvent) => {
+      e.preventDefault();
+      setPendingUrl("/mypage/experience"); // 명시적으로 뒤로가기 시 이동할 경로 지정
       setIsLeaveModalOpen(true);
-      history.pushState(null, "", window.location.href); // 이동 취소
     };
 
     // 링크 클릭 감지 (로고, 프로필 등)
@@ -137,11 +137,8 @@ export default function ExperienceRegisterPage() {
   // “예” → 이동하려던 페이지로
   const handleLeaveConfirm = () => {
     setIsLeaveModalOpen(false);
-    if (pendingUrl) {
-      router.push(pendingUrl);
-    } else {
-      router.push("/mypage/experience");
-    }
+    const targetUrl = pendingUrl || "/mypage/experience";
+    router.push(targetUrl);
   };
 
   // “아니오” → 현재 페이지 유지


### PR DESCRIPTION
### 📌 진행사항

* `experience-edit/[id]/layout.tsx`

  * GNB, Footer 추가하여 레이아웃 구조 통일

* `experience-edit/[id]/page.tsx`

  * 체험 수정 페이지에 **이탈 모달 로직 추가 및 연결**
  * 뒤로가기 시 `history.pushState`로 인해 이동이 막히던 문제 수정
    → `handlePopState`에서 `history.pushState` 제거
  * `handleLeaveConfirm` 내 `pendingUrl` 없을 때 기본 경로(`/mypage/experience`) 지정

* `experience-register/page.tsx`

  * 동일한 뒤로가기 이탈 이동 문제 수정 (`handlePopState`, `handleLeaveConfirm` 로직 통일)

### 🧩 수정 전 문제점

* 뒤로가기 시 `history.pushState`로 인해 이동 불가
* SPA 환경에서 `document.referrer`가 비어 `pendingUrl` 처리 실패 문제 우려됨.

### ✅ 수정 후 동작

* 뒤로가기 시 정상적으로 이탈 모달 표시
* “예” 클릭 시 `/mypage/experience`로 정상 이동
* `pendingUrl`이 없더라도 기본 경로로 이동하도록 안전 처리

### 🔧 추후 수정/보완 예정

* 등록/수정 페이지 공통 이탈 모달 로직을 커스텀 훅으로 리팩토링 해보기
* API 연동 후 `mockActivities` 제거 
 
### 🖼️ 스크린샷/이미지
**[내 체험 수정 페이지]**
<img width="1247" height="972" alt="image" src="https://github.com/user-attachments/assets/507de05d-3645-4e55-93a3-998d50541272" />

