### PR TITLE
[feature/experience] 예약 가능한 시간대 선택 시 같은 시간대 중복 생성 방지 및 날짜/캘린더 관련 버그 수정

### DIFF
--- a/src/app/mypage/experience/components/DateInput.tsx
+++ b/src/app/mypage/experience/components/DateInput.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useRef } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import Image from "next/image";
 import IconCalendar from "@/assets/icon/icon_calendar.svg";
+import { useState } from "react";
 
 interface DateInputProps {
   value: Date | null;
@@ -12,10 +12,15 @@ interface DateInputProps {
 }
 
 export default function DateInput({ value, onChange }: DateInputProps) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleIconClick = () => {
-    inputRef.current?.focus();
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleChange = (date: Date | null) => {
+    onChange(date);
+    setIsOpen(false); //  날짜 선택하면 닫힘
   };
 
   return (
@@ -26,7 +31,9 @@ export default function DateInput({ value, onChange }: DateInputProps) {
     >
       <DatePicker
         selected={value}
-        onChange={(date) => onChange(date)}
+        onChange={handleChange}
+        open={isOpen} // 직접 open 상태 제어
+        onClickOutside={() => setIsOpen(false)} // 외부 클릭 시 닫기
         dateFormat="yy/MM/dd"
         placeholderText="yy/mm/dd"
         className={`typo-16-m focus:outline-none

--- a/src/app/mypage/experience/components/DateSection.tsx
+++ b/src/app/mypage/experience/components/DateSection.tsx
@@ -33,9 +33,32 @@ export default function DateSection({
     return top.date && top.startTime && top.endTime;
   };
 
+  // 겹치는 시간대가 없도록 확인
+  const isOverlapping = (
+    slots: Slot[],
+    newSlot: Slot,
+    ignoreIndex?: number,
+  ) => {
+    return slots.some((slot, i) => {
+      if (i === ignoreIndex) return false;
+      if (slot.date !== newSlot.date) return false;
+      if (
+        !slot.startTime ||
+        !slot.endTime ||
+        !newSlot.startTime ||
+        !newSlot.endTime
+      )
+        return false;
+      return (
+        slot.startTime < newSlot.endTime && newSlot.startTime < slot.endTime
+      );
+    });
+  };
+
   const handleAdd = () => {
     if (!isTopSlotFilled()) return;
     const newSlot: Slot = { date: "", startTime: "", endTime: "" };
+    // 기존 isOverlapping 체크는 불필요했음 → 제거
     onChange?.([newSlot, ...value]);
   };
 
@@ -48,6 +71,11 @@ export default function DateSection({
     const updated = value.map((slot, i) =>
       i === index ? { ...slot, [key]: val } : slot,
     );
+    const changedSlot = updated[index];
+    if (isOverlapping(updated, changedSlot, index)) {
+      alert("같은 날짜 내에 겹치는 시간대가 있습니다.");
+      return;
+    }
     onChange?.(updated);
   };
 
@@ -60,9 +88,17 @@ export default function DateSection({
           <div className="flex flex-col sm:flex-row sm:items-center gap-3">
             <div className="flex-1">
               <DateInput
-                value={slot.date ? new Date(slot.date) : null}
+                value={
+                  slot.date
+                    ? new Date(`${slot.date}T00:00:00`) // 로컬 자정 기준으로 고정
+                    : null
+                }
                 onChange={(d) =>
-                  handleChange(i, "date", d?.toISOString().split("T")[0] ?? "")
+                  handleChange(
+                    i,
+                    "date",
+                    d ? d.toLocaleDateString("en-CA") : "", // 로컬 기준 yyyy-mm-dd
+                  )
                 }
               />
             </div>


### PR DESCRIPTION
### 📌 진행사항

- **같은 시간대에는 1개의 체험만 생성 가능하도록 로직 추가**
  - `isOverlapping()` 함수 추가로, 같은 날짜 내 겹치는 시간대 등록 시 `alert` 발생
  - 슬롯 입력 시 실시간 중복 검증 수행

- **날짜 하루 전으로 표시되는 UTC 파싱 문제 수정**
  - `toISOString()` → `toLocaleDateString("en-CA")` 로 변경
  - `new Date(slot.date)` → `new Date(${slot.date}T00:00:00)`로 수정하여 로컬 시간대 기준으로 날짜 고정

- **DateInput 캘린더 아이콘 클릭 시 달력 열림 기능 추가**
  - 기존 `ref` 기반 포커스 방식 제거
  - `open` 상태 제어로 토글 기능 직접 구현 (아이콘 클릭 시 열기/닫기 가능)

### 🖼️ 스크린샷/이미지
**[DateSection.tsx: 같은 시간대에는 1개의 체험만 생성]**
<img width="950" height="375" alt="image" src="https://github.com/user-attachments/assets/a4bda593-7e0d-4196-a492-b64358879186" />

