### PR TITLE
[feature/mainpage] 메인 페이지 무한스크롤을 제외한 필터링, 페이지네이션 및 검색 기능 구현

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import clsx from "clsx";
+
+interface DropdownProps {
+  options: string[];
+  onSelect: (value: string) => void;
+  label?: string;
+}
+
+export default function Dropdown({ options, onSelect, label }: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleSelect = (option: string) => {
+    setSelected(option);
+    onSelect(option);
+    setIsOpen(false);
+  };
+
+  // 외부 클릭 시 닫힘
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex items-center gap-[4px] typo-16-m text-text-primary leading-none"
+      >
+        {label ?? selected ?? "선택"}
+        <span className="w-4 h-4">▾</span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-[120px] rounded-xl border border-gray-100 bg-white shadow-lg z-50">
+          {options.map((option) => (
+            <button
+              key={option}
+              onClick={() => handleSelect(option)}
+              className={clsx(
+                "block w-full text-left px-4 py-2 typo-14-m hover:bg-gray-50",
+                selected === option && "font-semibold text-blue-500",
+              )}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
+import Image from "next/image";
 import clsx from "clsx";
+
+import iconArrowDown from "@/assets/icon/icon_alt arrow_down.svg";
+import iconArrowUp from "@/assets/icon/icon_alt arrow_up.svg";
 
 interface DropdownProps {
   options: string[];
@@ -12,7 +16,7 @@ interface DropdownProps {
 export default function Dropdown({ options, onSelect, label }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleSelect = (option: string) => {
     setSelected(option);
@@ -20,43 +24,59 @@ export default function Dropdown({ options, onSelect, label }: DropdownProps) {
     setIsOpen(false);
   };
 
-  // 외부 클릭 시 닫힘
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  // hover 시 지연 닫힘 처리
+  const handleMouseEnter = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setIsOpen(true);
+  };
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => setIsOpen(false), 150); // ← 150ms 지연
+  };
 
   return (
-    <div className="relative" ref={ref}>
+    <div
+      className="relative inline-block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {/* 버튼 */}
       <button
-        onClick={() => setIsOpen((prev) => !prev)}
-        className="flex items-center gap-[4px] typo-16-m text-text-primary leading-none"
+        type="button"
+        className="flex items-center gap-1 typo-16-m text-gray-950 leading-none pr-3"
       >
-        {label ?? selected ?? "선택"}
-        <span className="w-4 h-4">▾</span>
+        {label}
+        <Image
+          src={isOpen ? iconArrowUp : iconArrowDown}
+          alt="드롭다운 화살표"
+          width={20}
+          height={20}
+          className="w-5 h-5 object-contain transition-transform"
+        />
       </button>
 
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-[120px] rounded-xl border border-gray-100 bg-white shadow-lg z-50">
-          {options.map((option) => (
-            <button
-              key={option}
-              onClick={() => handleSelect(option)}
-              className={clsx(
-                "block w-full text-left px-4 py-2 typo-14-m hover:bg-gray-50",
-                selected === option && "font-semibold text-blue-500",
-              )}
-            >
-              {option}
-            </button>
-          ))}
-        </div>
-      )}
+      {/* 드롭다운 */}
+      <div
+        className={clsx(
+          "mt-2 absolute right-0 w-[103px] rounded-lg border border-gray-100 bg-white shadow-md z-50 transition-all duration-150",
+          isOpen
+            ? "opacity-100 translate-y-0 pointer-events-auto"
+            : "opacity-0 -translate-y-2 pointer-events-none",
+        )}
+      >
+        {options.map((option) => (
+          <button
+            key={option}
+            onClick={() => handleSelect(option)}
+            className={clsx(
+              "block w-full text-center px-6 py-4 typo-16-m hover:bg-gray-50",
+              selected === option && "font-semibold text-primary",
+            )}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -21,74 +21,100 @@ export default function Pagination({
   className,
 }: PaginationProps) {
   const go = (p: number) => onChange?.(Math.max(1, Math.min(totalPages, p)));
-
   const items = Array.from({ length: totalPages }, (_, i) => i + 1);
 
   return (
     <div
       className={clsx(
-        "w-full flex items-center justify-center gap-1 py-3 rounded-xl border-2 border-violet-300/60 border-dashed bg-white dark:bg-gray-900",
+        "w-full flex items-center justify-center gap-2 bg-white",
         className,
       )}
     >
       {/* 이전 버튼 */}
       <button
-        className="h-8 w-8 rounded-lg flex items-center justify-center group"
         onClick={() => go(page - 1)}
+        disabled={page === 1}
         aria-label="이전"
+        className={clsx(
+          "h-8 w-8 flex items-center justify-center transition",
+          page === 1
+            ? "opacity-40 cursor-default"
+            : "group hover:opacity-100 opacity-80",
+        )}
       >
-        <Image
-          src={chevronLeft}
-          alt="이전"
-          width={16}
-          height={16}
-          className="group-hover:hidden"
-        />
-        <Image
-          src={chevronLeftHover}
-          alt="이전(호버)"
-          width={16}
-          height={16}
-          className="hidden group-hover:block"
-        />
+        {page === 1 ? (
+          <Image src={chevronLeft} alt="이전" width={20} height={20} />
+        ) : (
+          <>
+            <Image
+              src={chevronLeft}
+              alt="이전"
+              width={20}
+              height={20}
+              className="group-hover:hidden"
+            />
+            <Image
+              src={chevronLeftHover}
+              alt="이전(호버)"
+              width={20}
+              height={20}
+              className="hidden group-hover:block"
+            />
+          </>
+        )}
       </button>
 
       {/* 페이지 번호 */}
-      {items.map((n) => (
-        <button
-          key={n}
-          onClick={() => go(n)}
-          className={clsx(
-            "h-8 w-8 rounded-lg typo-12-b",
-            n === page
-              ? "bg-primary text-white"
-              : "hover:bg-gray-100 dark:hover:bg-gray-800",
-          )}
-        >
-          {n}
-        </button>
-      ))}
+      <div className="flex items-center gap-1">
+        {items.map((n) => (
+          <button
+            key={n}
+            onClick={() => go(n)}
+            disabled={n === page}
+            className={clsx(
+              "relative w-10 h-10 typo-14-b transition-all duration-150",
+              n === page
+                ? "text-gray-950 after:absolute after:content-[''] after:left-0 after:bottom-0 after:w-full after:h-[2px] after:bg-primary"
+                : "text-gray-300 hover:text-gray-950",
+            )}
+          >
+            {n}
+          </button>
+        ))}
+      </div>
 
       {/* 다음 버튼 */}
       <button
-        className="h-8 w-8 rounded-lg flex items-center justify-center group"
         onClick={() => go(page + 1)}
+        disabled={page === totalPages}
         aria-label="다음"
+        className={clsx(
+          "h-8 w-8 flex items-center justify-center transition",
+          page === totalPages
+            ? "opacity-40 cursor-default"
+            : "group hover:opacity-100 opacity-80",
+        )}
       >
-        <Image
-          src={chevronRight}
-          alt="다음"
-          width={16}
-          height={16}
-          className="group-hover:hidden"
-        />
-        <Image
-          src={chevronRightHover}
-          alt="다음(호버)"
-          width={16}
-          height={16}
-          className="hidden group-hover:block"
-        />
+        {page === totalPages ? (
+          <Image src={chevronRight} alt="다음" width={20} height={20} />
+        ) : (
+          <>
+            <Image
+              src={chevronRight}
+              alt="다음"
+              width={20}
+              height={20}
+              className="group-hover:hidden"
+            />
+            <Image
+              src={chevronRightHover}
+              alt="다음(호버)"
+              width={20}
+              height={20}
+              className="hidden group-hover:block"
+            />
+          </>
+        )}
       </button>
     </div>
   );

--- a/src/components/experience-detail/ExperienceDetailReviews.tsx
+++ b/src/components/experience-detail/ExperienceDetailReviews.tsx
@@ -103,7 +103,7 @@ export default function ExperienceDetailReviews() {
           page={1}
           totalPages={5}
           onChange={(p) => console.log("페이지 이동:", p)}
-          className="border-none bg-transparent"
+          className="mt-10"
         />
       </div>
     </section>

--- a/src/components/experience-detail/ExperienceDetailReviews.tsx
+++ b/src/components/experience-detail/ExperienceDetailReviews.tsx
@@ -103,7 +103,7 @@ export default function ExperienceDetailReviews() {
           page={1}
           totalPages={5}
           onChange={(p) => console.log("페이지 이동:", p)}
-          className="border-none bg-transparent p-0"
+          className="border-none bg-transparent"
         />
       </div>
     </section>

--- a/src/components/main/CategorySection.tsx
+++ b/src/components/main/CategorySection.tsx
@@ -28,6 +28,13 @@ import hotairballoonImg from "@/assets/img/hotairballoon.png";
 import bicycleImg from "@/assets/img/bicycle.png";
 import tropicalfishImg from "@/assets/img/tropicalfish.png";
 
+interface CategorySectionProps {
+  selectedCategory: number | null;
+  onSelectCategory: (id: number | null) => void;
+  priceSortOrder: "asc" | "desc" | null;
+  onSelectPriceSort: (order: "asc" | "desc" | null) => void;
+}
+
 interface Category {
   id: number;
   name: string;
@@ -141,22 +148,24 @@ const activities: Activity[] = [
   },
 ];
 
-export default function CategorySection() {
-  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
-  const [priceSortOrder, setPriceSortOrder] = useState<"asc" | "desc" | null>(
-    null,
-  );
+export default function CategorySection({
+  selectedCategory,
+  onSelectCategory,
+  priceSortOrder,
+  onSelectPriceSort,
+}: CategorySectionProps) {
   const [currentPage, setCurrentPage] = useState(1);
 
   const itemsPerPage = 8;
 
   const handleSelectCategory = (id: number) => {
-    setSelectedCategory((prev) => (prev === id ? null : id));
+    onSelectCategory(selectedCategory === id ? null : id);
     setCurrentPage(1);
   };
 
   const handlePriceSortSelect = (option: string) => {
-    setPriceSortOrder(option === "높은 순" ? "desc" : "asc");
+    const order = option === "높은 순" ? "desc" : "asc";
+    onSelectPriceSort(order);
     setCurrentPage(1);
   };
 

--- a/src/components/main/CategorySection.tsx
+++ b/src/components/main/CategorySection.tsx
@@ -3,8 +3,8 @@
 import React, { useState } from "react";
 import Image, { type StaticImageData } from "next/image";
 import Card from "@/components/Card";
+import Dropdown from "@/components/Dropdown";
 
-import iconArrowDown from "@/assets/icon/icon_alt arrow_down.svg";
 import iconCulture from "@/assets/icon/icon_art.svg";
 import iconCultureWhite from "@/assets/icon/white/icon_art_white.svg";
 import iconFood from "@/assets/icon/icon_food.svg";
@@ -142,22 +142,33 @@ const activities: Activity[] = [
 
 export default function CategorySection() {
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [priceSortOrder, setPriceSortOrder] = useState<"asc" | "desc" | null>(
+    null,
+  );
   const [currentPage, setCurrentPage] = useState(1);
 
   const handleSelectCategory = (id: number) => {
     setSelectedCategory((prev) => (prev === id ? null : id));
   };
+
   const handlePageChange = (page: number) => setCurrentPage(page);
+
+  const handlePriceSortSelect = (option: string) => {
+    setPriceSortOrder(option === "높은 순" ? "desc" : "asc");
+  };
 
   const selected = categories.find((c) => c.id === selectedCategory);
 
-  const filteredActivities = (
+  const filteredActivities =
     selectedCategory === null
       ? activities
-      : activities.filter((act) => act.category === selected?.name)
-  ).sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  );
+      : activities.filter((act) => act.category === selected?.name);
+
+  const sortedActivities = [...filteredActivities].sort((a, b) => {
+    if (priceSortOrder === "asc") return a.price - b.price;
+    if (priceSortOrder === "desc") return b.price - a.price;
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(); // 기본값은 최신순
+  });
 
   return (
     <section className="px-6 md:px-8 lg:px-0 pt-10 pb-32 md:pb-[200px]">
@@ -174,17 +185,11 @@ export default function CategorySection() {
             {selectedCategory === null ? "모든 체험" : selected?.name}
           </h2>
         </div>
-        <button className="flex items-center gap-[4px] typo-16-m text-text-primary leading-none">
-          가격
-          <span className="relative w-5 h-5 flex-shrink-0">
-            <Image
-              src={iconArrowDown}
-              alt="가격 필터 버튼"
-              fill
-              className="object-contain"
-            />
-          </span>
-        </button>
+        <Dropdown
+          label="가격"
+          options={["높은 순", "낮은 순"]}
+          onSelect={handlePriceSortSelect}
+        />
       </div>
 
       <div className="flex gap-2 md:gap-5 mb-6 md:mb-8 overflow-x-auto scrollbar-hide">
@@ -217,7 +222,7 @@ export default function CategorySection() {
       </div>
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-x-4 md:gap-x-6 md:gap-y-7 gap-y-5">
-        {filteredActivities.map((act) => (
+        {sortedActivities.map((act) => (
           <Card key={act.id} className="!w-full">
             <Card.Image src={act.bannerImageUrl} alt={act.title} />
             <Card.Content>

--- a/src/components/main/CategorySection.tsx
+++ b/src/components/main/CategorySection.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import Image, { type StaticImageData } from "next/image";
 import Card from "@/components/Card";
 import Dropdown from "@/components/Dropdown";
+import Pagination from "@/components/Pagination";
 
 import iconCulture from "@/assets/icon/icon_art.svg";
 import iconCultureWhite from "@/assets/icon/white/icon_art_white.svg";
@@ -145,13 +146,10 @@ export default function CategorySection() {
   const [priceSortOrder, setPriceSortOrder] = useState<"asc" | "desc" | null>(
     null,
   );
-  const [currentPage, setCurrentPage] = useState(1);
 
   const handleSelectCategory = (id: number) => {
     setSelectedCategory((prev) => (prev === id ? null : id));
   };
-
-  const handlePageChange = (page: number) => setCurrentPage(page);
 
   const handlePriceSortSelect = (option: string) => {
     setPriceSortOrder(option === "높은 순" ? "desc" : "asc");
@@ -237,25 +235,12 @@ export default function CategorySection() {
         ))}
       </div>
 
-      <div className="flex justify-center items-center gap-3 mt-7 md:mt-10">
-        <button className="text-gray-400 hover:text-gray-700">&lt;</button>
-        <div className="flex items-center gap-3">
-          {[1, 2, 3, 4, 5].map((p) => (
-            <button
-              key={p}
-              onClick={() => handlePageChange(p)}
-              className={`w-6 h-6 rounded-md text-center ${
-                currentPage === p
-                  ? "text-blue-500 font-semibold border-b-2 border-blue-500"
-                  : "text-gray-400"
-              }`}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
-        <button className="text-gray-400 hover:text-gray-700">&gt;</button>
-      </div>
+      <Pagination
+        page={1}
+        totalPages={5}
+        onChange={(p) => console.log("페이지 이동:", p)}
+        className="border-none mt-10 bg-transparent"
+      />
     </section>
   );
 }

--- a/src/components/main/CategorySection.tsx
+++ b/src/components/main/CategorySection.tsx
@@ -43,6 +43,7 @@ interface Activity {
   reviewCount: number;
   price: number;
   category: string;
+  createdAt: string;
 }
 
 const categories: Category[] = [
@@ -85,6 +86,7 @@ const activities: Activity[] = [
     reviewCount: 108,
     price: 42800,
     category: "관광",
+    createdAt: "2025-10-01T09:00:00Z",
   },
   {
     id: 2,
@@ -94,6 +96,7 @@ const activities: Activity[] = [
     reviewCount: 67,
     price: 217000,
     category: "투어",
+    createdAt: "2025-09-15T08:00:00Z",
   },
   {
     id: 3,
@@ -103,6 +106,7 @@ const activities: Activity[] = [
     reviewCount: 113,
     price: 6000,
     category: "관광",
+    createdAt: "2025-08-10T10:00:00Z",
   },
   {
     id: 4,
@@ -112,6 +116,7 @@ const activities: Activity[] = [
     reviewCount: 85,
     price: 35000,
     category: "관광",
+    createdAt: "2025-08-20T10:00:00Z",
   },
   {
     id: 5,
@@ -121,6 +126,7 @@ const activities: Activity[] = [
     reviewCount: 108,
     price: 42800,
     category: "투어",
+    createdAt: "2025-05-01T10:00:00Z",
   },
   {
     id: 6,
@@ -130,6 +136,7 @@ const activities: Activity[] = [
     reviewCount: 18,
     price: 12000,
     category: "문화·예술",
+    createdAt: "2025-03-10T10:00:00Z",
   },
 ];
 
@@ -144,10 +151,13 @@ export default function CategorySection() {
 
   const selected = categories.find((c) => c.id === selectedCategory);
 
-  const filteredActivities =
+  const filteredActivities = (
     selectedCategory === null
       ? activities
-      : activities.filter((act) => act.category === selected?.name);
+      : activities.filter((act) => act.category === selected?.name)
+  ).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
 
   return (
     <section className="px-6 md:px-8 lg:px-0 pt-10 pb-32 md:pb-[200px]">

--- a/src/components/main/CategorySection.tsx
+++ b/src/components/main/CategorySection.tsx
@@ -146,13 +146,22 @@ export default function CategorySection() {
   const [priceSortOrder, setPriceSortOrder] = useState<"asc" | "desc" | null>(
     null,
   );
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const itemsPerPage = 8;
 
   const handleSelectCategory = (id: number) => {
     setSelectedCategory((prev) => (prev === id ? null : id));
+    setCurrentPage(1);
   };
 
   const handlePriceSortSelect = (option: string) => {
     setPriceSortOrder(option === "높은 순" ? "desc" : "asc");
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
   };
 
   const selected = categories.find((c) => c.id === selectedCategory);
@@ -167,6 +176,14 @@ export default function CategorySection() {
     if (priceSortOrder === "desc") return b.price - a.price;
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(); // 기본값은 최신순
   });
+
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const paginatedActivities = sortedActivities.slice(
+    startIndex,
+    startIndex + itemsPerPage,
+  );
+
+  const totalPages = Math.ceil(sortedActivities.length / itemsPerPage);
 
   return (
     <section className="px-6 md:px-8 lg:px-0 pt-10 pb-32 md:pb-[200px]">
@@ -220,7 +237,7 @@ export default function CategorySection() {
       </div>
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-x-4 md:gap-x-6 md:gap-y-7 gap-y-5">
-        {sortedActivities.map((act) => (
+        {paginatedActivities.map((act) => (
           <Card key={act.id} className="!w-full">
             <Card.Image src={act.bannerImageUrl} alt={act.title} />
             <Card.Content>
@@ -236,10 +253,10 @@ export default function CategorySection() {
       </div>
 
       <Pagination
-        page={1}
-        totalPages={5}
-        onChange={(p) => console.log("페이지 이동:", p)}
-        className="border-none mt-10 bg-transparent"
+        page={currentPage}
+        totalPages={Math.max(totalPages, 1)}
+        onChange={handlePageChange}
+        className="mt-10"
       />
     </section>
   );

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import backgroundSky from "@/assets/img/background_sky.png";
 import GNB from "@/components/GNB";
 import HeroSection from "@/components/main/HeroSection";
@@ -8,8 +8,130 @@ import Footer from "@/components/Footer";
 import SearchSection from "@/components/main/SearchSection";
 import PopularSection from "@/components/main/PopularSection";
 import CategorySection from "@/components/main/CategorySection";
+import Card from "@/components/Card";
+import Pagination from "@/components/Pagination";
+
+import fjordImg from "@/assets/img/fjord.png";
+import coastalvillageImg from "@/assets/img/coastalvillage.png";
+import reedforestImg from "@/assets/img/reedforest.png";
+import hotairballoonImg from "@/assets/img/hotairballoon.png";
+import bicycleImg from "@/assets/img/bicycle.png";
+import tropicalfishImg from "@/assets/img/tropicalfish.png";
+
+interface Activity {
+  id: number;
+  title: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  price: number;
+  category: string;
+  createdAt: string;
+}
+
+const mockActivities: Activity[] = [
+  {
+    id: 1,
+    title: "피오르 체험",
+    bannerImageUrl: fjordImg.src,
+    rating: 3.9,
+    reviewCount: 108,
+    price: 42800,
+    category: "관광",
+    createdAt: "2025-10-01T09:00:00Z",
+  },
+  {
+    id: 2,
+    title: "해안가 마을에서 1주일 살아보기",
+    bannerImageUrl: coastalvillageImg.src,
+    rating: 2.9,
+    reviewCount: 67,
+    price: 217000,
+    category: "투어",
+    createdAt: "2025-09-15T08:00:00Z",
+  },
+  {
+    id: 3,
+    title: "부모님과 함께 갈대숲 체험",
+    bannerImageUrl: reedforestImg.src,
+    rating: 4.0,
+    reviewCount: 113,
+    price: 6000,
+    category: "관광",
+    createdAt: "2025-08-10T10:00:00Z",
+  },
+  {
+    id: 4,
+    title: "열기구 페스티벌",
+    bannerImageUrl: hotairballoonImg.src,
+    rating: 4.1,
+    reviewCount: 85,
+    price: 35000,
+    category: "관광",
+    createdAt: "2025-08-20T10:00:00Z",
+  },
+  {
+    id: 5,
+    title: "베트남 자전거 여행",
+    bannerImageUrl: bicycleImg.src,
+    rating: 3.9,
+    reviewCount: 108,
+    price: 42800,
+    category: "투어",
+    createdAt: "2025-05-01T10:00:00Z",
+  },
+  {
+    id: 6,
+    title: "다양한 열대어 구경하기",
+    bannerImageUrl: tropicalfishImg.src,
+    rating: 4.3,
+    reviewCount: 18,
+    price: 12000,
+    category: "문화·예술",
+    createdAt: "2025-03-10T10:00:00Z",
+  },
+];
 
 export default function Main() {
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<Activity[]>([]);
+
+  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
+  const itemsPerPage = 8;
+
+  const handleSearch = (keyword: string) => {
+    setSearchKeyword(keyword);
+
+    if (keyword.trim() === "") {
+      setIsSearching(false);
+      setSearchResults([]);
+      return;
+    }
+
+    const results = mockActivities
+      .filter((act) => act.title.toLowerCase().includes(keyword.toLowerCase()))
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+
+    setSearchResults(results);
+    setIsSearching(true);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const paginatedResults = searchResults.slice(
+    startIndex,
+    startIndex + itemsPerPage,
+  );
+  const totalPages = Math.ceil(searchResults.length / itemsPerPage);
+
   return (
     <main
       className="min-h-screen bg-top bg-no-repeat bg-cover"
@@ -24,20 +146,71 @@ export default function Main() {
       </div>
 
       <div className="px-6 md:px-16 lg:px-[439px]">
-        <SearchSection />
+        <SearchSection onSearch={handleSearch} />
       </div>
 
-      <div className="px-6 md:px-8">
-        <div className="max-w-[1120px] mx-auto">
-          <PopularSection />
-        </div>
-      </div>
+      {isSearching ? (
+        <div className="px-6 md:px-8 pt-11 md:pt-18 lg:pt-[90px] pb-32 md:pb-[200px]">
+          <div className="max-w-[1120px] mx-auto">
+            <h2 className="typo-18-m md:text-2xl mb-2 text-gray-950">
+              <span className="font-bold">{searchKeyword}</span> (으)로 검색한
+              결과입니다.
+            </h2>
+            <p className="typo-14-m md:text-lg text-gray-700 mb-7">
+              총 {searchResults.length}개의 결과
+            </p>
 
-      <div className="px-6 md:px-8">
-        <div className="max-w-[1120px] mx-auto">
-          <CategorySection />
+            {searchResults.length === 0 ? (
+              <div className="typo-18-m text-center text-gray-700 py-20">
+                일치하는 체험이 없습니다.
+              </div>
+            ) : (
+              <>
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-x-4 md:gap-x-6 md:gap-y-7 gap-y-5 pb-20">
+                  {paginatedResults.map((act) => (
+                    <Card key={act.id} className="!w-full">
+                      <Card.Image src={act.bannerImageUrl} alt={act.title} />
+                      <Card.Content>
+                        <Card.Title className="line-clamp-1">
+                          {act.title}
+                        </Card.Title>
+                        <Card.Meta
+                          rating={act.rating}
+                          count={act.reviewCount}
+                        />
+                        <Card.Price
+                          price={`₩ ${act.price.toLocaleString()}`}
+                          unit="/ 인"
+                        />
+                      </Card.Content>
+                    </Card>
+                  ))}
+                </div>
+
+                <Pagination
+                  page={currentPage}
+                  totalPages={Math.max(totalPages, 1)}
+                  onChange={handlePageChange}
+                />
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      ) : (
+        <>
+          <div className="px-6 md:px-8">
+            <div className="max-w-[1120px] mx-auto">
+              <PopularSection />
+            </div>
+          </div>
+
+          <div className="px-6 md:px-8">
+            <div className="max-w-[1120px] mx-auto">
+              <CategorySection />
+            </div>
+          </div>
+        </>
+      )}
 
       <Footer />
     </main>

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -96,6 +96,10 @@ export default function Main() {
   const [searchKeyword, setSearchKeyword] = useState("");
   const [isSearching, setIsSearching] = useState(false);
   const [searchResults, setSearchResults] = useState<Activity[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [priceSortOrder, setPriceSortOrder] = useState<"asc" | "desc" | null>(
+    null,
+  );
 
   const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
   const itemsPerPage = 8;
@@ -106,6 +110,8 @@ export default function Main() {
     if (keyword.trim() === "") {
       setIsSearching(false);
       setSearchResults([]);
+      setSelectedCategory(null);
+      setPriceSortOrder(null);
       return;
     }
 
@@ -206,7 +212,12 @@ export default function Main() {
 
           <div className="px-6 md:px-8">
             <div className="max-w-[1120px] mx-auto">
-              <CategorySection />
+              <CategorySection
+                selectedCategory={selectedCategory}
+                onSelectCategory={setSelectedCategory}
+                priceSortOrder={priceSortOrder}
+                onSelectPriceSort={setPriceSortOrder}
+              />
             </div>
           </div>
         </>

--- a/src/components/main/SearchSection.tsx
+++ b/src/components/main/SearchSection.tsx
@@ -1,12 +1,29 @@
 "use client";
-
-import React from "react";
+import React, { useState } from "react";
 import clsx from "clsx";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
 import iconSearch from "@/assets/icon/icon_search.svg";
 
-export default function SearchSection() {
+interface SearchSectionProps {
+  onSearch: (keyword: string) => void;
+}
+
+export default function SearchSection({ onSearch }: SearchSectionProps) {
+  const [keyword, setKeyword] = useState("");
+
+  // 엔터 입력 시 검색 실행
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onSearch(keyword);
+    }
+  };
+
+  const handleClick = () => {
+    onSearch(keyword);
+  };
+
   return (
     <section className="pt-8 md:pt-16 lg:pt-20">
       <h2 className="text-base md:text-3xl font-bold text-center mb-4 md:mb-9 lg:mb-10">
@@ -16,12 +33,14 @@ export default function SearchSection() {
       <div className="relative w-full mx-auto">
         <Input
           placeholder="내가 원하는 체험은"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onKeyDown={handleKeyDown}
           leadingIconSrc={iconSearch}
           leadingIconAlt="검색"
           className={clsx(
             "w-full [&>div>input]:!h-[53px] [&>div>input]:!py-[13px]",
             "[&>div>input]:border-none [&>div>input]:shadow-searchbar",
-
             "md:[&>div>span:first-child]:!pl-8",
             "md:[&>div>input]:!pl-16 md:[&>div>input]:!h-[70px]",
             "md:[&>div>input]:placeholder:text-lg",
@@ -32,6 +51,7 @@ export default function SearchSection() {
           variant="primary"
           size="md"
           label="검색하기"
+          onClick={handleClick}
           className={clsx(
             "absolute top-1/2 right-2 md:right-3 -translate-y-1/2",
             "!h-10 !px-5 rounded-xl",


### PR DESCRIPTION
## 📌 진행사항
- [x] 드롭 다운으로 가격이 낮은 순 / 높은 순 선택을 하면 정렬이 됩니다. (페이지네이션)
- [x] 검색어를 입력하고 '검색하기' 버튼을 누르면 검색어가 포함된 제목을 가진 체험으로 정렬이 됩니다. (페이지네이션 | 검색어 포함 최신순)
- [x] 검색 필터 기준은 키워드가 제목에 일부라도 포함되는 경우 모두 검색이 됩니다.
- [x] 검색을 할때 카테고리 or 가격 순 필터가 설정되어 있다면 모두 초기화 됩니다.
- [x] 모든 체험은 최신순으로 정렬됩니다.(페이지네이션)

## 🔧 추후 수정/보완 예정
- 인기 체험과 관련한 무한스크롤 기능은 진행 중에 있습니다.

## 🖼️ 스크린샷 / 이미지

<img width="1822" height="1087" alt="스크린샷 2025-10-22 오후 10 54 29" src="https://github.com/user-attachments/assets/3979ce12-84ce-4944-a651-a0709b6f545a" />
→ 기본으로 카드 리스트는 최신순으로 정렬

<img width="1822" height="1087" alt="스크린샷 2025-10-22 오후 10 54 37" src="https://github.com/user-attachments/assets/db63f057-06e6-4fe7-837c-87a4ff7f34ed" />
→ 가격 버튼을 호버해 높은 순/낮은 순 드롭다운 메뉴를 선택하면 가격에 따라 카드 리스트 재정렬

<img width="1822" height="1087" alt="스크린샷 2025-10-22 오후 10 54 51" src="https://github.com/user-attachments/assets/082a3093-64ee-47c4-ba04-09c004531dff" />
→ 검색 인풋에 특정 키워드 입력 시 그 키워드를 포함한 체험 카드 리스트 표시 (최신순으로 정렬)

<img width="1822" height="1087" alt="스크린샷 2025-10-22 오후 10 55 04" src="https://github.com/user-attachments/assets/5bbcc2e5-3dca-451f-84c5-9beb67021c52" />
→ 검색 결과가 없을 시 '일치하는 체험이 없습니다.' 문구 표시 (이 부분은 임의로 설정하였습니다)