### PR TITLE
feat: 예약 페이지 무한 스크롤 및 상태별 버튼 노출 개선

### DIFF
--- a/src/app/mypage/bookings/mock/mockReservations.ts
+++ b/src/app/mypage/bookings/mock/mockReservations.ts
@@ -11,15 +11,16 @@ export type MockReservation = {
   totalPrice: number;
 };
 
+const img1 =
+  "https://images.unsplash.com/photo-1606112219348-204d7d8b94ee?w=800";
+const img2 =
+  "https://images.unsplash.com/photo-1606787366850-de6330128bfc?w=800";
+
 export const mockReservations: MockReservation[] = [
   {
     id: 1,
-    activity: {
-      title: "서울 야경 사진 투어",
-      bannerImageUrl:
-        "https://images.unsplash.com/photo-1606112219348-204d7d8b94ee?w=800",
-    },
-    date: "2025-10-10",
+    activity: { title: "서울 야경 사진 투어", bannerImageUrl: img1 },
+    date: "2025-10-01",
     startTime: "18:00",
     endTime: "21:00",
     status: "confirmed",
@@ -27,12 +28,8 @@ export const mockReservations: MockReservation[] = [
   },
   {
     id: 2,
-    activity: {
-      title: "한강 요트 체험",
-      bannerImageUrl:
-        "https://images.unsplash.com/photo-1606112219348-204d7d8b94ee?w=800",
-    },
-    date: "2025-10-12",
+    activity: { title: "한강 요트 체험", bannerImageUrl: img1 },
+    date: "2025-10-02",
     startTime: "14:00",
     endTime: "17:00",
     status: "pending",
@@ -40,12 +37,8 @@ export const mockReservations: MockReservation[] = [
   },
   {
     id: 3,
-    activity: {
-      title: "북촌 한옥 마을 투어",
-      bannerImageUrl:
-        "https://images.unsplash.com/photo-1606787366850-de6330128bfc?w=800",
-    },
-    date: "2025-10-20",
+    activity: { title: "북촌 한옥 마을 투어", bannerImageUrl: img2 },
+    date: "2025-10-03",
     startTime: "10:00",
     endTime: "12:00",
     status: "completed",
@@ -53,15 +46,107 @@ export const mockReservations: MockReservation[] = [
   },
   {
     id: 4,
-    activity: {
-      title: "한옥 요리 클래스",
-      bannerImageUrl:
-        "https://images.unsplash.com/photo-1606787366850-de6330128bfc?w=800",
-    },
-    date: "2025-10-25",
+    activity: { title: "한옥 요리 클래스", bannerImageUrl: img2 },
+    date: "2025-10-04",
     startTime: "11:00",
     endTime: "13:00",
     status: "canceled",
     totalPrice: 90000,
   },
+  {
+    id: 5,
+    activity: { title: "남산 타워 전망 투어", bannerImageUrl: img1 },
+    date: "2025-10-05",
+    startTime: "19:00",
+    endTime: "21:00",
+    status: "confirmed",
+    totalPrice: 70000,
+  },
+  {
+    id: 6,
+    activity: { title: "서울 성곽길 트래킹", bannerImageUrl: img1 },
+    date: "2025-10-06",
+    startTime: "09:00",
+    endTime: "11:00",
+    status: "pending",
+    totalPrice: 50000,
+  },
+  {
+    id: 7,
+    activity: { title: "광장시장 미식 투어", bannerImageUrl: img2 },
+    date: "2025-10-07",
+    startTime: "12:00",
+    endTime: "14:00",
+    status: "completed",
+    totalPrice: 45000,
+  },
+  {
+    id: 8,
+    activity: { title: "인사동 도자기 체험", bannerImageUrl: img2 },
+    date: "2025-10-08",
+    startTime: "15:00",
+    endTime: "17:00",
+    status: "declined",
+    totalPrice: 70000,
+  },
+  {
+    id: 9,
+    activity: { title: "서울 궁궐 야간 탐방", bannerImageUrl: img1 },
+    date: "2025-10-09",
+    startTime: "19:00",
+    endTime: "22:00",
+    status: "pending",
+    totalPrice: 80000,
+  },
+  {
+    id: 10,
+    activity: { title: "홍대 거리 버스킹 투어", bannerImageUrl: img2 },
+    date: "2025-10-10",
+    startTime: "17:00",
+    endTime: "20:00",
+    status: "completed",
+    totalPrice: 55000,
+  },
+  // --- 👇 아래로 11~50번까지 패턴 반복 ---
+  ...Array.from({ length: 40 }, (_, i) => {
+    const id = i + 11;
+    const titles = [
+      "서울 역사 박물관 투어",
+      "이태원 글로벌 미식 체험",
+      "강남 커피 로스팅 클래스",
+      "잠실 석촌호수 자전거 투어",
+      "서울 아트페어 감상 투어",
+      "성수 핸드메이드 워크숍",
+      "서울 플리마켓 투어",
+      "남대문 패션 마켓 투어",
+      "한강 피크닉 체험",
+      "삼청동 도보 투어",
+    ];
+    const statuses: MockReservation["status"][] = [
+      "pending",
+      "canceled",
+      "confirmed",
+      "declined",
+      "completed",
+    ];
+    const title = titles[i % titles.length];
+    const status = statuses[i % statuses.length];
+    const date = `2025-11-${(i % 30) + 1}`.padStart(10, "0");
+    const startTime = `${9 + (i % 8)}:00`;
+    const endTime = `${11 + (i % 8)}:00`;
+    const price = 50000 + (i % 5) * 10000;
+
+    return {
+      id,
+      activity: {
+        title,
+        bannerImageUrl: i % 2 === 0 ? img1 : img2,
+      },
+      date,
+      startTime,
+      endTime,
+      status,
+      totalPrice: price,
+    } as MockReservation;
+  }),
 ];

--- a/src/app/mypage/bookings/mock/page.tsx
+++ b/src/app/mypage/bookings/mock/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import ListCard from "@/components/ListCard";
 import Button from "@/components/Button";
 import Modal from "@/components/Modal";
 import StarRatingInput from "@/components/StarRatingInput";
 import logoAuth from "@/assets/img/empty_state.png";
-import warningImg from "@/assets/img/warning_state.png"; // ✅ 경고 이미지 추가
+import warningImg from "@/assets/img/warning_state.png";
 import { mockReservations } from "./mockReservations";
 
 type ReservationFilter =
@@ -22,17 +22,66 @@ export default function MockBookingsPage() {
   const [filter, setFilter] = useState<ReservationFilter>("all");
   const [openCardId, setOpenCardId] = useState<number | null>(null);
 
-  // ✅ 후기 모달 상태
+  // 후기 모달
   const [openReviewModal, setOpenReviewModal] = useState(false);
   const [rating, setRating] = useState(0);
   const [content, setContent] = useState("");
   const [selectedReservation, setSelectedReservation] =
     useState<(typeof mockReservations)[number] | null>(null);
 
-  // ✅ 예약 취소 모달 상태
+  // 취소 모달
   const [openCancelModal, setOpenCancelModal] = useState(false);
   const [targetReservation, setTargetReservation] =
     useState<(typeof mockReservations)[number] | null>(null);
+
+  // ✅ 무한스크롤 상태
+  const [page, setPage] = useState(1);
+  const [displayed, setDisplayed] = useState<(typeof mockReservations)[number][]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const PAGE_SIZE = 5; // 페이지당 5개씩 표시
+
+  // ✅ 초기 및 페이지 변경 시 데이터 불러오기 (mock 기반)
+  useEffect(() => {
+  if (!hasMore) return;
+
+  const load = () => {
+    setIsFetching(true);
+    const start = (page - 1) * PAGE_SIZE;
+    const end = start + PAGE_SIZE;
+    const nextSlice = mockReservations.slice(start, end);
+
+    if (nextSlice.length === 0) {
+      setHasMore(false);
+    } else {
+      setDisplayed((prev) => [...prev, ...nextSlice]);
+    }
+
+    setIsFetching(false);
+  };
+
+  // ✅ setState 호출을 effect 본문이 아닌 별도 함수 안으로 분리
+  load();
+}, [page, hasMore]);
+
+  // ✅ IntersectionObserver: 스크롤 하단 감지
+  useEffect(() => {
+    if (!hasMore || isFetching) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setPage((prev) => prev + 1);
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    if (observerRef.current) observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [hasMore, isFetching]);
 
   // ✅ 필터 순서
   const filterOrder: ReservationFilter[] = [
@@ -44,37 +93,36 @@ export default function MockBookingsPage() {
     "completed",
   ];
 
-  // ✅ 예약 데이터가 없으면 필터 숨김, 하나라도 있으면 전체 표시
+  // ✅ 필터 표시 조건
   const availableFilters = useMemo(() => {
     if (mockReservations.length === 0) return [];
     return filterOrder;
-  }, [mockReservations, filterOrder]);
+  }, [mockReservations]);
 
   // ✅ 필터된 예약 목록
   const filtered = useMemo(
     () =>
       filter === "all"
-        ? mockReservations
-        : mockReservations.filter((r) => r.status === filter),
-    [mockReservations, filter]
+        ? displayed
+        : displayed.filter((r) => r.status === filter),
+    [displayed, filter]
   );
 
   const hasReservations = mockReservations.length > 0;
 
+  // ✅ 카드 토글
   const onCardClick = (id: number) => {
     setOpenCardId((prev) => (prev === id ? null : id));
   };
 
-  // ✅ 후기 작성 (mock)
+  // ✅ 후기 등록 (mock)
   const handleSubmitReview = () => {
     if (!selectedReservation) return;
-
     console.log("📢 후기 등록 (mock):", {
       reservationId: selectedReservation.id,
       rating,
       content,
     });
-
     setOpenReviewModal(false);
     setRating(0);
     setContent("");
@@ -83,17 +131,11 @@ export default function MockBookingsPage() {
   // ✅ 예약 취소 (mock)
   const handleCancelReservation = () => {
     if (!targetReservation) return;
-
     console.log("⚠️ 예약 취소 요청 (mock):", targetReservation.id);
-
-    // 예약 상태를 취소로 변경 (mock 업데이트)
     const index = mockReservations.findIndex(
       (r) => r.id === targetReservation.id
     );
-    if (index !== -1) {
-      mockReservations[index].status = "canceled";
-    }
-
+    if (index !== -1) mockReservations[index].status = "canceled";
     setOpenCancelModal(false);
     setTargetReservation(null);
   };
@@ -123,7 +165,7 @@ export default function MockBookingsPage() {
 
   return (
     <div className="space-y-6">
-      {/* ✅ 필터 */}
+      {/* 필터 */}
       {availableFilters.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {availableFilters.map((f) => (
@@ -145,7 +187,7 @@ export default function MockBookingsPage() {
         </div>
       )}
 
-      {/* ✅ 예약 카드 목록 */}
+      {/* 예약 카드 목록 */}
       <div className="space-y-4">
         {filtered.map((r) => (
           <div key={r.id}>
@@ -161,11 +203,10 @@ export default function MockBookingsPage() {
                 subtitle={`${r.date} · ${r.startTime} - ${r.endTime}`}
                 status={r.status}
                 price={`₩${r.totalPrice.toLocaleString()}`}
-                ctaLabel="자세히"
+                ctaLabel="후기 작성"
               />
             </div>
 
-            {/* ✅ 카드 하단 버튼 */}
             {openCardId === r.id && (
               <div className="mt-3 mb-4 flex justify-center gap-3">
                 {r.status === "pending" && (
@@ -203,9 +244,19 @@ export default function MockBookingsPage() {
             )}
           </div>
         ))}
+
+        {/* ✅ 무한스크롤 감시용 엘리먼트 */}
+        {hasMore && (
+          <div
+            ref={observerRef}
+            className="h-10 flex justify-center items-center text-gray-400"
+          >
+            {isFetching ? "불러오는 중..." : "아래로 스크롤"}
+          </div>
+        )}
       </div>
 
-      {/* ✅ 예약 취소 확인 모달 */}
+      {/* 예약 취소 모달 */}
       <Modal
         open={openCancelModal}
         onClose={() => setOpenCancelModal(false)}
@@ -228,7 +279,7 @@ export default function MockBookingsPage() {
         </div>
       </Modal>
 
-      {/* ✅ 후기 작성 모달 */}
+      {/* 후기 작성 모달 */}
       <Modal
         open={openReviewModal}
         onClose={() => {
@@ -243,7 +294,6 @@ export default function MockBookingsPage() {
       >
         {selectedReservation && (
           <>
-            {/* 제목 + 일정 */}
             <div className="text-center mb-4">
               <p className="typo-16-b text-gray-900">
                 {selectedReservation.activity.title}
@@ -253,11 +303,7 @@ export default function MockBookingsPage() {
                 {selectedReservation.endTime}
               </p>
             </div>
-
-            {/* 별점 입력 */}
             <StarRatingInput initialRating={rating} onChange={setRating} />
-
-            {/* 후기 입력 */}
             <div className="mt-5">
               <p className="typo-14-b mb-2 text-gray-800">
                 소중한 경험을 들려주세요

--- a/src/app/mypage/bookings/page.tsx
+++ b/src/app/mypage/bookings/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import ListCard from "@/components/ListCard";
 import Button from "@/components/Button";
-import Image from "next/image";
 import Modal from "@/components/Modal";
 import StarRatingInput from "@/components/StarRatingInput";
 import logoAuth from "@/assets/img/empty_state.png";
@@ -12,9 +12,14 @@ import warningImg from "@/assets/img/warning_state.png";
 import api from "@/utils/api";
 import { MyReservationsResponse, Reservation } from "@/types/reservation";
 
-type ReservationFilter = "all" | "pending" | "canceled" | "confirmed" | "declined" | "completed";
+type ReservationFilter =
+  | "all"
+  | "pending"
+  | "canceled"
+  | "confirmed"
+  | "declined"
+  | "completed";
 
-  // ✅ 필터 순서를 명시적으로 정의
 const filterOrder: ReservationFilter[] = [
   "all",
   "pending",
@@ -29,54 +34,91 @@ export default function BookingsPage() {
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<ReservationFilter>("all");
   const [openCardId, setOpenCardId] = useState<number | null>(null);
+
   const [openReviewModal, setOpenReviewModal] = useState(false);
   const [rating, setRating] = useState(0);
   const [content, setContent] = useState("");
-  const [selectedReservation, setSelectedReservation] = useState<Reservation | null>(null);
-  const [openCancelModal, setOpenCancelModal] = useState(false);
-  const [targetReservation, setTargetReservation] = useState<Reservation | null>(null);
+  const [selectedReservation, setSelectedReservation] =
+    useState<Reservation | null>(null);
 
-  // ✅ Hook 순서는 항상 일정해야 함
+  const [openCancelModal, setOpenCancelModal] = useState(false);
+  const [targetReservation, setTargetReservation] =
+    useState<Reservation | null>(null);
+
+  // ✅ 무한 스크롤 상태
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const PAGE_SIZE = 5;
+
+  // ✅ 예약 데이터 불러오기 (React 권장 구조)
   useEffect(() => {
-    async function fetchReservations() {
+    if (!hasMore) return;
+
+    const loadReservations = async () => {
       try {
-        const res = await api.get<MyReservationsResponse>("/my-reservations");
-        setReservations(res.reservations);
+        setIsFetching(true);
+        const res = await api.get<MyReservationsResponse>(
+          `/my-reservations?page=${page}&limit=${PAGE_SIZE}`
+        );
+
+        if (res.reservations.length === 0) {
+          setHasMore(false);
+        } else {
+          setReservations((prev) => [...prev, ...res.reservations]);
+        }
       } catch (err) {
         console.error("예약 리스트 조회 실패:", err);
       } finally {
+        setIsFetching(false);
         setLoading(false);
       }
-    }
-    fetchReservations();
-  }, []);
+    };
 
-  // ✅ useMemo는 절대 조건문 안에 넣지 않음
+    loadReservations();
+  }, [page, hasMore]);
+
+  // ✅ IntersectionObserver (스크롤 감지)
+  useEffect(() => {
+    if (!hasMore || isFetching) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setPage((prev) => prev + 1);
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    if (observerRef.current) observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [hasMore, isFetching]);
+
+  // ✅ 필터 적용
   const filtered = useMemo(
     () => reservations.filter((r) => (filter === "all" ? true : r.status === filter)),
     [reservations, filter]
   );
 
-
-
-  // ✅ 예약 데이터가 없으면 필터 숨김, 하나라도 있으면 전체 목록 표시
+  // ✅ 필터 표시 여부
   const availableFilters = useMemo(() => {
-    if (reservations.length === 0) return []; // 데이터 없으면 필터 안 보이게
-    return filterOrder; // 하나라도 있으면 전체 필터 표시
+    if (reservations.length === 0) return [];
+    return filterOrder;
   }, [reservations]);
 
-  // 후기 작성 핸들러
+  // ✅ 후기 제출
   const handleSubmitReview = async () => {
     if (!selectedReservation) return;
     try {
-      // TODO: 후기 API 연동 예정
       console.log("후기 등록:", {
         reservationId: selectedReservation.id,
         rating,
         content,
       });
-
-      // 성공 후 초기화
+      // TODO: 후기 등록 API 연동 예정
       setOpenReviewModal(false);
       setRating(0);
       setContent("");
@@ -85,19 +127,17 @@ export default function BookingsPage() {
     }
   };
 
+  // ✅ 예약 취소
   const handleCancelReservation = async () => {
     if (!targetReservation) return;
     try {
       console.log("예약 취소 요청:", targetReservation.id);
-      // TODO: 실제 취소 API 연동 예정 (예: await api.post(`/reservations/${targetReservation.id}/cancel`))
-
-      // 취소 성공 시 상태 업데이트 (선택적)
+      // TODO: 실제 API 연동 예정
       setReservations((prev) =>
         prev.map((r) =>
           r.id === targetReservation.id ? { ...r, status: "canceled" } : r
         )
       );
-
       setOpenCancelModal(false);
       setTargetReservation(null);
     } catch (err) {
@@ -106,7 +146,6 @@ export default function BookingsPage() {
   };
 
   if (loading) {
-    // Hook 이후 return 해야 함 (조건부 Hook 금지)
     return <p>로딩 중...</p>;
   }
 
@@ -122,7 +161,7 @@ export default function BookingsPage() {
               key={f}
               onClick={() => {
                 setFilter(f);
-                setOpenCardId(null); // ✅ 필터 변경 시 열려 있던 카드 닫기
+                setOpenCardId(null);
               }}
               className={`px-4 py-2 rounded-full border ${
                 filter === f
@@ -151,11 +190,10 @@ export default function BookingsPage() {
               subtitle={`${r.date} · ${r.startTime} - ${r.endTime}`}
               status={r.status}
               price={`₩${r.totalPrice.toLocaleString()}`}
-              ctaLabel="자세히"
+              ctaLabel="후기 작성"
             />
           </div>
 
-          {/* ✅ 카드 아래 버튼 */}
           {openCardId === r.id && (
             <div className="mt-3 mb-4 flex justify-center gap-3">
               {r.status === "pending" && (
@@ -164,10 +202,7 @@ export default function BookingsPage() {
                     label="예약 변경"
                     variant="secondary"
                     className="w-1/3 h-11"
-                    onClick={() => {
-                      // TODO: 예약 변경 기능 추가 예정
-                      console.log("예약 변경 클릭");
-                    }}
+                    onClick={() => console.log("예약 변경 클릭")}
                   />
                   <Button
                     label="예약 취소"
@@ -175,7 +210,7 @@ export default function BookingsPage() {
                     className="w-1/3 h-11"
                     onClick={() => {
                       setTargetReservation(r);
-                      setOpenCancelModal(true); // 취소 모달 열기
+                      setOpenCancelModal(true);
                     }}
                   />
                 </>
@@ -187,8 +222,8 @@ export default function BookingsPage() {
                   variant="primary"
                   className="w-2/3 h-11"
                   onClick={() => {
-                    setSelectedReservation(r);   // 클릭된 예약 정보를 저장
-                    setOpenReviewModal(true);    // 후기 모달 열기
+                    setSelectedReservation(r);
+                    setOpenReviewModal(true);
                   }}
                 />
               )}
@@ -196,6 +231,16 @@ export default function BookingsPage() {
           )}
         </div>
       ))}
+
+      {/* ✅ 무한스크롤 감시용 엘리먼트 */}
+      {hasMore && (
+        <div
+          ref={observerRef}
+          className="h-10 flex justify-center items-center text-gray-400"
+        >
+          {isFetching ? "불러오는 중..." : "아래로 스크롤"}
+        </div>
+      )}
 
       {/* ✅ 예약 취소 확인 모달 */}
       <Modal
@@ -207,16 +252,8 @@ export default function BookingsPage() {
         widthClass="max-w-xs"
       >
         <div className="flex flex-col items-center text-center">
-          <Image
-            src={warningImg}
-            alt="경고"
-            width={72}
-            height={72}
-            className="mb-4"
-          />
-          <p className="typo-16-b text-gray-900 mb-2">
-            예약을 취소하시겠어요?
-          </p>
+          <Image src={warningImg} alt="경고" width={72} height={72} className="mb-4" />
+          <p className="typo-16-b text-gray-900 mb-2">예약을 취소하시겠어요?</p>
         </div>
       </Modal>
 
@@ -231,25 +268,18 @@ export default function BookingsPage() {
       >
         {selectedReservation && (
           <>
-            {/* 제목 + 일정 */}
             <div className="text-center mb-4">
               <p className="typo-16-b text-gray-900">
                 {selectedReservation.activity.title}
               </p>
               <p className="typo-14-m text-gray-500">
                 {selectedReservation.date} / {selectedReservation.startTime} -{" "}
-                {/* {selectedReservation.endTime} ({selectedReservation.participants}명) */}
+                {selectedReservation.endTime}
               </p>
             </div>
-
-            {/* 별점 입력 */}
             <StarRatingInput initialRating={rating} onChange={setRating} />
-
-            {/* 후기 입력 */}
             <div className="mt-5">
-              <p className="typo-14-b mb-2 text-gray-800">
-                소중한 경험을 들려주세요
-              </p>
+              <p className="typo-14-b mb-2 text-gray-800">소중한 경험을 들려주세요</p>
               <textarea
                 className="w-full h-28 border border-gray-200 rounded-2xl p-4 text-gray-800 placeholder:text-gray-400 resize-none focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="체험에서 느낀 경험을 자유롭게 남겨주세요"
@@ -269,7 +299,7 @@ export default function BookingsPage() {
     <section className="flex flex-col items-center justify-center text-center py-20">
       <Image src={logoAuth} alt="예약 없음" width={122} height={122} className="mb-4" />
       <p className="typo-16-m text-gray-600 mb-[30px]">아직 예약한 체험이 없어요</p>
-      <Link href="/activities">
+      <Link href="/">
         <Button label="둘러보기" variant="primary" className="w-[182px] h-[54px]" />
       </Link>
     </section>

--- a/src/app/mypage/calendar/page.tsx
+++ b/src/app/mypage/calendar/page.tsx
@@ -88,7 +88,7 @@ export default function CalendarPage() {
         <p className="typo-16-m text-gray-600 mb-[30px]">
           아직 등록한 체험이 없어요
         </p>
-        <Link href="/mypage/experience/register">
+        <Link href="/experience-register">
           <Button
             label="체험 등록하기"
             variant="primary"

--- a/src/components/ListCard.stories.tsx
+++ b/src/components/ListCard.stories.tsx
@@ -29,10 +29,10 @@ const meta = {
       control: "inline-radio",
       options: ["pc", "mobile"],
     },
-    forceMobileState: {
-      control: "inline-radio",
-      options: ["done", "ing"],
-    },
+    // forceMobileState: {
+    //   control: "inline-radio",
+    //   options: ["done", "ing"],
+    // },
     actionsDisabled: { control: "boolean" },
   },
 } satisfies Meta<typeof ListCard>;
@@ -104,6 +104,6 @@ export const MobileProgress: Story = {
     title: "열기구 체험 (진행중)",
     price: "₩ 35,000",
     subtitle: "성인 2명 · 11:00–12:30",
-    forceMobileState: "ing", // ✅ 진행중 상태 강제
+    // forceMobileState: "ing", // ✅ 진행중 상태 강제
   },
 };

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -166,7 +166,11 @@ export default function ListCard({
 
         {/* 버튼: 카드+이미지 전체 폭(410px)에 맞춤 */}
         <div className="mt-3 w-[410px]">
-          {mobileState === "done" ? DoneCTA : ProgressActions}
+          {status === "completed"
+            ? DoneCTA
+            : status === "pending"
+            ? ProgressActions
+            : null}
         </div>
       </div>
     );
@@ -212,7 +216,11 @@ export default function ListCard({
             {priceSub && <span className="typo-12-m text-text-secondary ml-1">{priceSub}</span>}
             <span className="typo-12-m text-text-secondary ml-1">/ {peopleText}</span>
           </div>
-          {status === "completed" ? DoneCTA : ProgressActions}
+          {status === "completed"
+            ? DoneCTA
+            : status === "pending"
+            ? ProgressActions
+            : null}
         </div>
       </div>
 

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -10,7 +10,7 @@ export type ReservationStatus =
   | "canceled"
   | "completed";
 
-type MobileState = "done" | "ing"; // done=후기작성 / ing=예약변경·취소
+// type MobileState = "done" | "ing"; // done=후기작성 / ing=예약변경·취소 // 모바일 코드 변경으로 사용 안함
 
 export interface ListCardProps {
   // 공통 필수
@@ -39,7 +39,7 @@ export interface ListCardProps {
   showActions?: boolean;
 
   // 모바일 테스트용
-  forceMobileState?: MobileState;
+  // forceMobileState?: MobileState; // 모바일 코드 변경으로 사용 안함
   actionsDisabled?: boolean;
 }
 
@@ -71,12 +71,12 @@ export default function ListCard({
   onClickChange,
   onClickCancel,
   variant = "pc",
-  forceMobileState,
+  // forceMobileState, // 모바일 코드 변경으로 사용 안함
   actionsDisabled,
 }: ListCardProps) {
   const { v: tagVariant, t: tagText } = badge(status);
-  const mobileState: MobileState =
-    forceMobileState ?? (status === "completed" ? "done" : "ing");
+  // const mobileState: MobileState =
+  //   forceMobileState ?? (status === "completed" ? "done" : "ing"); 모바일 코드 변경으로 사용 안함
   const hasSubtitle = !!subtitle?.trim();
 
   const ProgressActions = (


### PR DESCRIPTION
## ✨ 작업 개요
- 예약 페이지 무한 스크롤 구현
- 예약 상태에 따른 버튼 노출 제어 (pending / completed만 표시) - 공통컴포넌트 ListCard.tsx 

## 🛠 변경 사항
- `src/app/mypage/bookings/page.tsx` : 실제 API 기반 무한 스크롤 적용
- `src/app/mypage/bookings/mock/page.tsx` : mock 데이터 기반 무한 스크롤 적용
- `src/components/ListCard.tsx` : 상태별 버튼 노출 조건 분기 개선

## ✅ 확인 사항
- [x] 빌드 문제 없음
- [x] 예약 상태별 버튼 노출 정상 작동

## ✨ 추가 작업
- ListCard 컴포넌트에서 사용되지 않는 mobileState 및 forceMobileState 주석처리
- 예약 상태별 버튼 노출 로직 수정:
  - pending → 예약 변경 / 취소 버튼 노출
  - completed → 후기 작성 버튼 노출
  - 나머지 상태 → 버튼 미노출
- Storybook 관련 불필요 prop 제거
- npm run build 성공 (빌드 및 타입 검사 완료)