### PR TITLE
[feature/experience] 내 체험 관리 CRUD API 연동 및 이미지 업로드 기능 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  images: {
+    domains: ["sprint-fe-project.s3.ap-northeast-2.amazonaws.com"],
+  },
+};
+
+export default nextConfig;

--- a/src/app/experience-edit/[id]/layout.tsx
+++ b/src/app/experience-edit/[id]/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import GNB from "@/components/GNB";
 import Footer from "@/components/Footer";
+import Protected from "@/components/auth-detail/Protected";
 
 export default function ExperienceRegisterLayout({
   children,
@@ -8,10 +9,12 @@ export default function ExperienceRegisterLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div>
-      <GNB isLoggedIn unread={3} />
-      {children}
-      <Footer />
-    </div>
+    <Protected>
+      <div>
+        <GNB isLoggedIn unread={3} />
+        {children}
+        <Footer />
+      </div>
+    </Protected>
   );
 }

--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -10,39 +10,15 @@ import CategorySelect from "@/app/mypage/experience/components/CategorySelect";
 import AddressInput from "@/app/mypage/experience/components/AddressInput";
 import DateSection from "@/app/mypage/experience/components/DateSection";
 import PhotoSection from "@/app/mypage/experience/components/PhotoSection";
-import { CreateActivityRequest } from "@/types/experience";
-// testImg 나중에 인증 권한 해결 후 지울 예정
-import streetdanceImg from "@/assets/img/streetdance_main.png";
+import {
+  CreateActivityRequest,
+  UpdateActivityRequest,
+  ActivitiesResponse,
+} from "@/types/experience";
 import Image from "next/image";
 import warning from "@/assets/img/warning_state.png";
-
-const mockActivities: (CreateActivityRequest & { id: number })[] = Array.from(
-  { length: 40 },
-  (_, i) => ({
-    id: i + 1,
-    title: `체험 ${i + 1}번 타이틀`,
-    category: "액티비티",
-    description: `이건 ${i + 1}번 체험의 설명이에요.`,
-    address: `서울시 어딘가 ${i + 1}번지`,
-    price: 50000 + (i + 1) * 1000,
-    bannerImageUrl: streetdanceImg.src as string,
-    subImageUrls: [],
-    schedules: [
-      {
-        date: "2025-10-25",
-        startTime: "09:00",
-        endTime: "12:00",
-      },
-    ],
-  }),
-);
-
-interface MyActivitiesResponse {
-  activities: {
-    id: number;
-    [key: string]: unknown;
-  }[];
-}
+import api from "@/utils/api";
+import { updateActivity } from "@/app/mypage/experience/api/activities";
 
 export default function ExperienceEditPage() {
   const router = useRouter();
@@ -59,11 +35,10 @@ export default function ExperienceEditPage() {
   const { data, isLoading } = useQuery({
     queryKey: ["activityDetail", id],
     queryFn: async () => {
-      const target = mockActivities.find((a) => a.id === Number(id));
-      return target!;
-      // 나중엔 아래처럼 교체하면 됨:
-      // return getActivityDetail(Number(id));
+      const res = await api.get(`/activities/${id}`);
+      return res as CreateActivityRequest & { id: number };
     },
+    enabled: !Number.isNaN(id),
   });
 
   useEffect(() => {
@@ -78,19 +53,15 @@ export default function ExperienceEditPage() {
   }, [data, form]);
 
   const mutation = useMutation({
-    mutationFn: async (payload: CreateActivityRequest) => {
-      // 나중엔 아래로 교체
-      // return updateActivity(Number(id), payload);
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      console.log("mock update", payload);
-      return { ...payload, id: Number(id) };
+    mutationFn: async (payload: UpdateActivityRequest) => {
+      return updateActivity(id, payload);
     },
     onSuccess: (updated) => {
       // 캐시 즉시 수정
-      queryClient.setQueryData<MyActivitiesResponse | undefined>(
+      queryClient.setQueryData<ActivitiesResponse | undefined>(
         ["myActivities"],
-        (oldData) => {
-          if (!oldData) return oldData;
+        (oldData: ActivitiesResponse | undefined) => {
+          if (!oldData?.activities) return oldData;
           return {
             ...oldData,
             activities: oldData.activities.map((a) =>
@@ -99,6 +70,7 @@ export default function ExperienceEditPage() {
           };
         },
       );
+
       // 서버 데이터 다시 불러오기
       queryClient.invalidateQueries({ queryKey: ["myActivities"] });
       queryClient.invalidateQueries({ queryKey: ["activityDetail", id] });

--- a/src/app/experience-register/layout.tsx
+++ b/src/app/experience-register/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import GNB from "@/components/GNB";
 import Footer from "@/components/Footer";
+import Protected from "@/components/auth-detail/Protected";
 
 export default function ExperienceRegisterLayout({
   children,
@@ -8,12 +9,12 @@ export default function ExperienceRegisterLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div>
-      {/* TODO: 공용 레이아웃 적용 후 GNB 제거 예정 */}
-      <GNB isLoggedIn unread={3} />
-      {children}
-      {/* TODO: 공용 레이아웃 적용 후 Footer 제거 예정 */}
-      <Footer />
-    </div>
+    <Protected>
+      <div>
+        <GNB isLoggedIn unread={3} />
+        {children}
+        <Footer />
+      </div>
+    </Protected>
   );
 }

--- a/src/app/mypage/experience/api/activities.ts
+++ b/src/app/mypage/experience/api/activities.ts
@@ -33,3 +33,21 @@ export const updateActivity = async (
 export const deleteActivity = async (activityId: number): Promise<void> => {
   await api.delete(`/my-activities/${activityId}`);
 };
+
+// 이미지 업로드 API 추가
+export const uploadActivityImage = async (file: File): Promise<string> => {
+  const formData = new FormData();
+  formData.append("image", file);
+
+  const response = await api.post<{ activityImageUrl: string }>(
+    `/activities/image`,
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    },
+  );
+
+  return response.activityImageUrl;
+};

--- a/src/app/mypage/experience/components/PhotoSection.tsx
+++ b/src/app/mypage/experience/components/PhotoSection.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import ImageUpload from "./ImageUpload";
 import Image from "next/image";
 import IconDelete from "@/assets/icon/icon_delete_button.svg";
+import { uploadActivityImage } from "@/app/mypage/experience/api/activities";
 
 interface PhotoSectionProps {
   limit?: number; // 업로드 가능한 이미지 개수 제한
@@ -17,20 +18,45 @@ export default function PhotoSection({
   onChange,
 }: PhotoSectionProps) {
   const [images, setImages] = useState<string[]>(value ?? []);
+  const [isUploading, setIsUploading] = useState(false);
 
   useEffect(() => {
-    setImages(value);
+    setImages((prev) => {
+      // 배열 길이나 원소가 완전히 동일하면 업데이트 안 함
+      const isSame =
+        prev.length === value.length && prev.every((v, i) => v === value[i]);
+      return isSame ? prev : value;
+    });
   }, [value]);
 
-  const handleUpload = (newFiles: File[]) => {
+  // 이미지 업로드 함수 추가
+  const uploadImage = async (file: File): Promise<string> => {
+    try {
+      return await uploadActivityImage(file);
+    } catch (error) {
+      console.error("이미지 업로드 실패:", error);
+      throw error;
+    }
+  };
+
+  const handleUpload = async (newFiles: File[]) => {
     if (images.length >= limit) return;
 
-    // 🔹 Blob URL로 변환 (메모리에만 존재)
-    const urls = newFiles.map((f) => URL.createObjectURL(f));
-    const updated = [...images, ...urls].slice(0, limit);
+    setIsUploading(true);
+    try {
+      // 모든 파일을 순차적으로 업로드
+      const uploadPromises = newFiles.map((file) => uploadImage(file));
+      const uploadedUrls = await Promise.all(uploadPromises);
 
-    setImages(updated);
-    onChange?.(updated);
+      const updated = [...images, ...uploadedUrls].slice(0, limit);
+      setImages(updated);
+      onChange?.(updated);
+    } catch (error) {
+      console.error("이미지 업로드 중 오류 발생:", error);
+      alert("이미지 업로드에 실패했습니다.");
+    } finally {
+      setIsUploading(false);
+    }
   };
 
   const handleRemove = (index: number) => {
@@ -45,7 +71,7 @@ export default function PhotoSection({
         onChange={handleUpload}
         limit={limit}
         count={images.length}
-        disabled={images.length >= limit}
+        disabled={images.length >= limit || isUploading}
       />
 
       {images.map((src, idx) => (

--- a/src/app/mypage/experience/layout.tsx
+++ b/src/app/mypage/experience/layout.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import Link from "next/link";
 import Button from "@/components/Button";
-import GNB from "@/components/GNB";
-import Footer from "@/components/Footer";
-import SideMenu from "@/components/SideMenu";
 
 export default function ExperienceLayout({
   children,
@@ -11,43 +8,22 @@ export default function ExperienceLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div>
-      {/* TODO: 공용 레이아웃 적용 후 GNB 제거 예정 */}
-      <GNB isLoggedIn unread={3} />
-
-      <main className="min-h-screen bg-bg-default text-text-primary">
-        <div className="mx-auto max-w-[1200px] p-6 md:p-8 lg:p-10">
-          <div className="grid grid-cols-1 md:grid-cols-[178px_minmax(0,1fr)] lg:grid-cols-[290px_minmax(0,1fr)] gap-6 lg:gap-10">
-            {/* LEFT */}
-            {/* 모바일 상태에서는 hidden, md 이상부터는 block */}
-            <aside className="hidden md:block space-y-6">
-              <SideMenu />
-            </aside>
-
-            {/* RIGHT */}
-            <div className="space-y-8">
-              {/* 헤더 */}
-              <header className="flex flex-wrap items-center justify-between lg:w-[640px] gap-3">
-                <div>
-                  <h1 className="typo-18-b">내 체험 관리</h1>
-                  <p className="mt-2 typo-14-m text-gray-500">
-                    체험을 등록하거나 수정 및 삭제가 가능합니다.
-                  </p>
-                </div>
-                <Link href="/experience-register">
-                  <Button label="체험 등록하기" variant="primary" />
-                </Link>
-              </header>
-
-              {/* 카드 리스트 자리 */}
-              {children}
-            </div>
-          </div>
+    <section className="space-y-8">
+      {/* 헤더 */}
+      <header className="flex flex-wrap items-center justify-between lg:w-[640px] gap-3">
+        <div>
+          <h1 className="typo-18-b">내 체험 관리</h1>
+          <p className="mt-2 typo-14-m text-gray-500">
+            체험을 등록하거나 수정 및 삭제가 가능합니다.
+          </p>
         </div>
-      </main>
+        <Link href="/experience-register">
+          <Button label="체험 등록하기" variant="primary" />
+        </Link>
+      </header>
 
-      {/* TODO: 공용 레이아웃 적용 후 Footer 제거 예정 */}
-      <Footer />
-    </div>
+      {/* 콘텐츠 자리 */}
+      {children}
+    </section>
   );
 }

--- a/src/app/mypage/experience/page.tsx
+++ b/src/app/mypage/experience/page.tsx
@@ -13,8 +13,8 @@ import {
 } from "@tanstack/react-query";
 import warning from "@/assets/img/warning_state.png";
 import { ActivitiesResponse } from "@/types/experience";
-// testImg 나중에 인증 권한 해결 후 지울 예정
-import streetdanceImg from "@/assets/img/streetdance_main.png";
+import api from "@/utils/api";
+import { deleteActivity } from "@/app/mypage/experience/api/activities";
 
 export default function ExperiencePage() {
   const router = useRouter();
@@ -28,34 +28,7 @@ export default function ExperiencePage() {
   }>(null);
 
   // --------------------------
-  // mock 데이터 (10페이지 x 4개)
-  // --------------------------
-  const mockPages: ActivitiesResponse[] = Array.from(
-    { length: 10 },
-    (_, pageIdx) => ({
-      activities: Array.from({ length: 4 }, (_, i) => {
-        const id = pageIdx * 4 + i + 1;
-        return {
-          id,
-          userId: 0,
-          title: `체험 ${id}번 타이틀`,
-          description: `이건 ${id}번 체험의 설명이에요.`,
-          category: "액티비티",
-          price: 50000 + id * 1000,
-          address: `서울시 어딘가 ${id}번지`,
-          bannerImageUrl: streetdanceImg.src,
-          reviewCount: Math.floor(Math.random() * 50),
-          rating: Number((Math.random() * 1.5 + 3.5).toFixed(1)), // number로 변환
-          createdAt: new Date(Date.now() - id * 1000 * 60 * 60).toISOString(),
-          updatedAt: new Date(Date.now() - id * 1000 * 60 * 60).toISOString(),
-        };
-      }),
-      nextCursorId: pageIdx < 9 ? pageIdx + 1 : null,
-      hasNext: pageIdx < 9,
-    }),
-  );
-  // --------------------------
-  // useInfiniteQuery (현재는 mock으로 대체)
+  // useInfiniteQuery
   // --------------------------
   const queryClient = useQueryClient();
 
@@ -69,20 +42,15 @@ export default function ExperiencePage() {
   } = useInfiniteQuery<ActivitiesResponse>({
     queryKey: ["myActivities"],
     // 나중에 백엔드 API 붙이면 여기에 getMyActivities 호출
-    queryFn: async ({ pageParam = 0 }) => {
-      const index = Number(pageParam);
-      await new Promise((r) => setTimeout(r, 500)); // 로딩 시뮬레이션
-      return (
-        mockPages[index] ?? {
-          activities: [],
-          nextCursorId: null,
-          hasNext: false,
-        }
+    queryFn: async ({ pageParam }) => {
+      const cursorQuery = pageParam ? `?cursorId=${pageParam}` : "";
+      const res = await api.get<ActivitiesResponse>(
+        `/my-activities${cursorQuery}`,
       );
+      return res;
     },
-    getNextPageParam: (lastPage, pages) =>
-      lastPage.hasNext ? pages.length : undefined,
-    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextCursorId ?? undefined,
+    initialPageParam: undefined,
   });
 
   // 모든 페이지 병합 후 최신순 정렬
@@ -117,35 +85,57 @@ export default function ExperiencePage() {
       {
         root: container,
         threshold: 0, // 더 일찍 감지하도록 0으로 설정
-        rootMargin: "100px",
+        rootMargin: "300px",
       },
     );
 
-    observer.observe(loadMoreRef.current);
+    if (hasNextPage) observer.observe(loadMoreRef.current);
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage, activities.length]);
 
+  type MyActivitiesCache = {
+    pages: ActivitiesResponse[];
+    pageParams: unknown[];
+  };
+  type DeleteContext = { previous?: MyActivitiesCache };
+
   // --------------------------
-  // 삭제 Mutation (mock 기반)
+  // 삭제 Mutation
   // --------------------------
   const deleteMutation = useMutation({
-    mutationFn: async (id: number) => id,
-    onSuccess: (id) => {
+    mutationFn: async (id: number) => {
+      return deleteActivity(id); // api 호출
+    },
+    onMutate: async (id: number): Promise<DeleteContext> => {
+      await queryClient.cancelQueries({ queryKey: ["myActivities"] });
+      const previous = queryClient.getQueryData<{
+        pages: ActivitiesResponse[];
+        pageParams: unknown[];
+      }>(["myActivities"]);
       queryClient.setQueryData<{
         pages: ActivitiesResponse[];
         pageParams: unknown[];
       }>(["myActivities"], (oldData) => {
         if (!oldData) return oldData;
-
         return {
           ...oldData,
-          pages: oldData.pages.map((page) => ({
+          pages: oldData.pages.map((page: ActivitiesResponse) => ({
             ...page,
             activities: page.activities.filter((a) => a.id !== id),
           })),
         };
       });
-
+      return { previous };
+    },
+    onError: (_err, _id, context?: DeleteContext) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["myActivities"], context.previous);
+      }
+      alert("삭제 중 오류가 발생했습니다.");
+    },
+    onSuccess: () => {
+      // 서버 기준으로 재동기화
+      queryClient.invalidateQueries({ queryKey: ["myActivities"] });
       setDeleteModalOpen(false);
       setSelectedActivity(null);
     },


### PR DESCRIPTION
### 📌 진행사항

* **Mock 데이터 제거 및 실제 CRUD API 연동**

  * `experience-edit`, `experience-register`, `mypage/experience` 등에서
    기존 mock 데이터 의존 제거하고 `/activities`, `/my-activities` 실서버 API 연결.
  * `updateActivity`, `createActivity`, `deleteActivity` 등 API 모듈 통합 관리.

* **이미지 업로드 기능 개선**

  * `PhotoSection` 컴포넌트에서 `Blob` 처리 제거하고,
    업로드 시 S3 presigned URL 기반 API(`uploadActivityImage`) 호출하도록 변경.
  * 업로드 성공 시 반환된 실제 이미지 URL을 form에 반영.

* **권한 보호 적용**
  * `MypageLayout` 및 관련 페이지(`experience-edit`, `experience-register`)에
    `Protected` HOC 적용하여 비로그인 접근 차단.

* **이미지 업로드 도메인 허용 추가**
  * `next.config.js`에 `sprint-fe-project.s3.ap-northeast-2.amazonaws.com` 도메인 추가.

### 🧠 추후 수정 / 보완 예정

* DateSection 날짜 추가 문제 오류 해결 예정

