### PR TITLE
[feature/experience detail] 체험 상세 페이지 소개 이미지 및 케밥 버튼 표시 등 확인된 오류 수정

### DIFF
--- a/src/components/experience-detail/ExperienceDetail.tsx
+++ b/src/components/experience-detail/ExperienceDetail.tsx
@@ -25,7 +25,8 @@ interface Activity {
   price: number;
   address: string;
   bannerImageUrl: string;
-  subImages: SubImage[];
+  subImages?: SubImage[];
+  subImageUrls?: string[];
   reviewCount: number;
   rating: number;
 }
@@ -45,29 +46,30 @@ export default function ExperienceDetail({
       try {
         console.log("체험 상세 데이터 요청 시작");
 
-        // 타입 명시 (api.ts에서 .data만 반환하므로)
-        const activityRes = (await api.get("activities?method=offset")) as {
-          activities: Activity[];
-          totalCount: number;
-        };
+        const activityRes = (await api.get(
+          `activities/${activityId}`,
+        )) as Activity;
 
-        console.log("API 응답 데이터:", activityRes);
-
-        if (!activityRes || !activityRes.activities) {
-          console.error("activities 데이터가 없습니다:", activityRes);
+        if (!activityRes) {
+          console.error("activity 데이터가 없습니다:", activityRes);
           return;
         }
 
-        const foundActivity = activityRes.activities.find(
-          (a: Activity) => a.id === activityId,
-        );
+        const normalizedActivity: Activity = {
+          ...activityRes,
+          subImages:
+            activityRes.subImages && activityRes.subImages.length > 0
+              ? activityRes.subImages
+              : activityRes.subImageUrls
+                ? activityRes.subImageUrls.map((url, idx) => ({
+                    id: idx,
+                    imageUrl: url,
+                  }))
+                : [],
+        };
 
-        if (foundActivity) {
-          setActivity(foundActivity);
-          console.log("찾은 체험:", foundActivity);
-        } else {
-          console.warn(`id ${activityId} 체험을 찾을 수 없습니다.`);
-        }
+        setActivity(normalizedActivity);
+        console.log("정규화된 체험:", normalizedActivity);
       } catch (err) {
         console.error("체험 상세 조회 실패:", err);
       }
@@ -87,7 +89,7 @@ export default function ExperienceDetail({
         <div className="lg:hidden flex flex-col">
           <ExperienceDetailImages
             images={
-              activity.subImages?.length
+              Array.isArray(activity.subImages) && activity.subImages.length > 0
                 ? activity.subImages
                 : [{ id: 0, imageUrl: activity.bannerImageUrl }]
             }
@@ -118,7 +120,8 @@ export default function ExperienceDetail({
           <div className="flex flex-col">
             <ExperienceDetailImages
               images={
-                activity.subImages?.length
+                Array.isArray(activity.subImages) &&
+                activity.subImages.length > 0
                   ? activity.subImages
                   : [{ id: 0, imageUrl: activity.bannerImageUrl }]
               }

--- a/src/components/experience-detail/ExperienceDetail.tsx
+++ b/src/components/experience-detail/ExperienceDetail.tsx
@@ -39,7 +39,7 @@ export default function ExperienceDetail({
   activityId,
 }: ExperienceDetailProps) {
   const [activity, setActivity] = useState<Activity | null>(null);
-  const [isOwner] = useState(false);
+  const [isOwner, setIsOwner] = useState(false);
 
   useEffect(() => {
     async function fetchData() {
@@ -55,6 +55,11 @@ export default function ExperienceDetail({
           return;
         }
 
+        const storedAuth = localStorage.getItem("auth-storage");
+        const currentUser = storedAuth
+          ? JSON.parse(storedAuth)?.state?.user
+          : null;
+
         const normalizedActivity: Activity = {
           ...activityRes,
           subImages:
@@ -69,6 +74,14 @@ export default function ExperienceDetail({
         };
 
         setActivity(normalizedActivity);
+
+        // 작성자 본인인지 확인
+        if (currentUser && currentUser.id === normalizedActivity.userId) {
+          setIsOwner(true);
+        } else {
+          setIsOwner(false);
+        }
+
         console.log("정규화된 체험:", normalizedActivity);
       } catch (err) {
         console.error("체험 상세 조회 실패:", err);

--- a/src/components/experience-detail/ExperienceDetailImages.tsx
+++ b/src/components/experience-detail/ExperienceDetailImages.tsx
@@ -2,6 +2,22 @@ interface ExperienceDetailImagesProps {
   images: { id: number; imageUrl: string }[];
 }
 
+const getCornerClass = (idx: number, length: number) => {
+  const last = length - 1;
+  switch (idx) {
+    case 0:
+      return "rounded-tl-2xl";
+    case 1:
+      return "rounded-tr-2xl";
+    case last - 1:
+      return "rounded-bl-2xl";
+    case last:
+      return "rounded-br-2xl";
+    default:
+      return "";
+  }
+};
+
 export default function ExperienceDetailImages({
   images,
 }: ExperienceDetailImagesProps) {
@@ -23,44 +39,49 @@ export default function ExperienceDetailImages({
         </div>
       ) : images.length === 2 ? (
         // 2장일 때: 반반 배치
-        <div className="grid grid-cols-2 gap-4">
-          {images.map((img) => (
-            <img
-              key={img.id}
-              src={img.imageUrl}
-              alt={`체험 이미지 ${img.id}`}
-              className="w-full h-full object-cover rounded-2xl"
-            />
-          ))}
-        </div>
-      ) : images.length === 3 ? (
-        // 3장일 때: 왼쪽 세로형 + 오른쪽 두 개
-        <div className="grid grid-cols-[2fr_1fr] grid-rows-2 gap-4 h-[400px]">
+        <div className="grid grid-cols-2 gap-3">
           <img
             src={images[0].imageUrl}
-            alt="대표 이미지"
-            className="row-span-2 w-full h-full object-cover rounded-2xl"
+            alt="소개 이미지 1"
+            className="w-full h-full object-cover rounded-l-2xl"
           />
           <img
             src={images[1].imageUrl}
-            alt="보조 이미지 1"
-            className="w-full h-full object-cover rounded-2xl"
+            alt="소개 이미지 2"
+            className="w-full h-full object-cover rounded-r-2xl"
+          />
+        </div>
+      ) : images.length === 3 ? (
+        // 3장일 때: 왼쪽 세로형 + 오른쪽 두 개
+        <div className="grid grid-cols-[1.4fr_1fr] grid-rows-2 gap-2 md:gap-3 h-[245px] md:h-[400px]">
+          <img
+            src={images[0].imageUrl}
+            alt="소개 이미지1"
+            className="row-span-2 w-full h-full object-cover rounded-l-2xl"
+          />
+          <img
+            src={images[1].imageUrl}
+            alt="소개 이미지 2"
+            className="w-full h-full object-cover rounded-tr-2xl"
           />
           <img
             src={images[2].imageUrl}
-            alt="보조 이미지 2"
-            className="w-full h-full object-cover rounded-2xl"
+            alt="소개 이미지 3"
+            className="w-full h-full object-cover rounded-br-2xl"
           />
         </div>
       ) : (
         // 4장 이상: 기본 2열 그리드
-        <div className="grid grid-cols-2 gap-4">
-          {images.map((img) => (
+        <div className="grid grid-cols-2 gap-3">
+          {images.map((img, idx) => (
             <img
               key={img.id}
               src={img.imageUrl}
               alt={`체험 이미지 ${img.id}`}
-              className="w-full h-auto object-cover rounded-2xl"
+              className={`w-full h-auto object-cover ${getCornerClass(
+                idx,
+                images.length,
+              )}`}
             />
           ))}
         </div>


### PR DESCRIPTION
## 📌 진행사항
- [x] 기존 체험 상세 페이지에서 배너 이미지 1장만 보이던 오류를 소개 이미지 1~4장이 정상적으로 표시되도록 수정했습니다.
- [x] 내가 등록한 체험임에도 케밥 버튼이 보이지 않는 오류가 있어 수정했습니다.
(유성님께서 새로고침해도 유저 정보 누락되지 않도록 수정해 주셨다고 합니다!) 

## 🔧 추후 수정/보완 예정
- 드롭다운 메뉴 중 삭제하기를 눌렀을 때 모달 띄운 후 삭제가 가능하도록 작업하고 있습니다.

## 🖼️ 스크린샷 / 이미지

<img width="1822" height="1087" alt="스크린샷 2025-10-27 오전 11 22 48" src="https://github.com/user-attachments/assets/5a177913-7152-42b5-82cd-b8c8f0c8cc05" />
→ 혹시 이미지 비율이나 다른 부분에서 의견이 있으시면 알려주세요!