### PR TITLE
[Calendar] 예약 패널 api 연동 및 드롭다운 UI 개선 / ESLint 경고 해소

### DIFF
--- a/src/app/mypage/calendar/api/reservationApi.ts
+++ b/src/app/mypage/calendar/api/reservationApi.ts
@@ -1,4 +1,5 @@
 import api from "@/utils/api";
+import { AxiosError } from "axios";
 
 /** ===============================
  * 📘 내 체험 리스트 조회
@@ -20,9 +21,13 @@ export const getMyActivities = async () => {
 
     console.log("✅ [getMyActivities] 응답:", res);
     return res;
-  } catch (error: any) {
-    console.error("❌ [getMyActivities] 실패:", error);
-    throw error;
+  } catch (error) {
+    const err = error as AxiosError;
+    console.error("❌ [getMyActivities] 실패:", {
+      status: err.response?.status,
+      message: err.response?.data,
+    });
+    throw err;
   }
 };
 
@@ -51,9 +56,13 @@ export const getReservationDashboard = async (
 
     console.log("✅ [getReservationDashboard] 응답:", res);
     return res;
-  } catch (error: any) {
-    console.error("❌ [getReservationDashboard] 실패:", error);
-    throw error;
+  } catch (error) {
+    const err = error as AxiosError;
+    console.error("❌ [getReservationDashboard] 실패:", {
+      status: err.response?.status,
+      message: err.response?.data,
+    });
+    throw err;
   }
 };
 
@@ -66,7 +75,6 @@ export const getReservedSchedule = async (
   date: string
 ) => {
   try {
-    // ✅ 서버는 YYYY-MM-DD 형식만 허용
     const formattedDate = date.includes(".")
       ? date.split(".").join("-")
       : date;
@@ -95,12 +103,13 @@ export const getReservedSchedule = async (
 
     console.log("✅ [getReservedSchedule] 응답:", res);
     return res;
-  } catch (error: any) {
+  } catch (error) {
+    const err = error as AxiosError;
     console.error("❌ [getReservedSchedule] 실패:", {
-      status: error?.response?.status,
-      message: error?.response?.data || error.message,
+      status: err.response?.status,
+      message: err.response?.data,
     });
-    throw error;
+    throw err;
   }
 };
 
@@ -132,12 +141,13 @@ export const getReservationsBySchedule = async (
 
     console.log("✅ [getReservationsBySchedule] 응답:", res);
     return res;
-  } catch (error: any) {
+  } catch (error) {
+    const err = error as AxiosError;
     console.error("❌ [getReservationsBySchedule] 실패:", {
-      status: error?.response?.status,
-      message: error?.response?.data || error.message,
+      status: err.response?.status,
+      message: err.response?.data || err.message,
     });
-    throw error;
+    throw err;
   }
 };
 
@@ -162,11 +172,12 @@ export const updateReservationStatus = async (
       status,
     });
     return res;
-  } catch (error: any) {
+  } catch (error) {
+    const err = error as AxiosError;
     console.error("❌ [updateReservationStatus] 실패:", {
-      status: error?.response?.status,
-      message: error?.response?.data || error.message,
+      status: err.response?.status,
+      message: err.response?.data || err.message,
     });
-    throw error;
+    throw err;
   }
 };

--- a/src/app/mypage/calendar/api/reservationApi.ts
+++ b/src/app/mypage/calendar/api/reservationApi.ts
@@ -1,0 +1,172 @@
+import api from "@/utils/api";
+
+/** ===============================
+ * 📘 내 체험 리스트 조회
+ * GET /{teamId}/my-activities
+ * =============================== */
+export const getMyActivities = async () => {
+  try {
+    const res = await api.get<{
+      cursorId: number;
+      totalCount: number;
+      activities: {
+        id: number;
+        title: string;
+        category: string;
+        price: number;
+        bannerImageUrl: string;
+      }[];
+    }>("/my-activities");
+
+    console.log("✅ [getMyActivities] 응답:", res);
+    return res;
+  } catch (error: any) {
+    console.error("❌ [getMyActivities] 실패:", error);
+    throw error;
+  }
+};
+
+/** ===============================
+ * 📘 내 체험 월별 예약 현황 조회
+ * GET /{teamId}/my-activities/{activityId}/reservation-dashboard
+ * =============================== */
+export const getReservationDashboard = async (
+  activityId: number,
+  year: string,
+  month: string
+) => {
+  try {
+    const res = await api.get<
+      {
+        date: string;
+        reservations: {
+          completed: number;
+          confirmed: number;
+          pending: number;
+        };
+      }[]
+    >(`/my-activities/${activityId}/reservation-dashboard`, {
+      params: { year, month },
+    });
+
+    console.log("✅ [getReservationDashboard] 응답:", res);
+    return res;
+  } catch (error: any) {
+    console.error("❌ [getReservationDashboard] 실패:", error);
+    throw error;
+  }
+};
+
+/** ===============================
+ * 📘 특정 날짜별 예약 스케줄 조회
+ * GET /{teamId}/my-activities/{activityId}/reserved-schedule
+ * =============================== */
+export const getReservedSchedule = async (
+  activityId: number,
+  date: string
+) => {
+  try {
+    // ✅ 서버는 YYYY-MM-DD 형식만 허용
+    const formattedDate = date.includes(".")
+      ? date.split(".").join("-")
+      : date;
+
+    console.log("📡 [getReservedSchedule] 요청 정보:", {
+      activityId,
+      originalDate: date,
+      formattedDate,
+      url: `/my-activities/${activityId}/reserved-schedule`,
+    });
+
+    const res = await api.get<
+      {
+        scheduleId: number;
+        startTime: string;
+        endTime: string;
+        count: {
+          declined: number;
+          confirmed: number;
+          pending: number;
+        };
+      }[]
+    >(`/my-activities/${activityId}/reserved-schedule`, {
+      params: { date: formattedDate },
+    });
+
+    console.log("✅ [getReservedSchedule] 응답:", res);
+    return res;
+  } catch (error: any) {
+    console.error("❌ [getReservedSchedule] 실패:", {
+      status: error?.response?.status,
+      message: error?.response?.data || error.message,
+    });
+    throw error;
+  }
+};
+
+/** ===============================
+ * 📘 예약 내역 조회 (신청/승인/거절)
+ * GET /{teamId}/my-activities/{activityId}/reservations
+ * =============================== */
+export const getReservationsBySchedule = async (
+  activityId: number,
+  scheduleId: number,
+  status: "pending" | "confirmed" | "declined"
+) => {
+  try {
+    const res = await api.get<{
+      cursorId: number;
+      totalCount: number;
+      reservations: {
+        id: number;
+        nickname: string;
+        headCount: number;
+        status: string;
+        date: string;
+        startTime: string;
+        endTime: string;
+      }[];
+    }>(`/my-activities/${activityId}/reservations`, {
+      params: { scheduleId, status, size: 10 },
+    });
+
+    console.log("✅ [getReservationsBySchedule] 응답:", res);
+    return res;
+  } catch (error: any) {
+    console.error("❌ [getReservationsBySchedule] 실패:", {
+      status: error?.response?.status,
+      message: error?.response?.data || error.message,
+    });
+    throw error;
+  }
+};
+
+/** ===============================
+ * 📘 예약 상태 변경 (승인/거절)
+ * PATCH /{teamId}/my-activities/{activityId}/reservations/{reservationId}
+ * =============================== */
+export const updateReservationStatus = async (
+  activityId: number,
+  reservationId: number,
+  status: "confirmed" | "declined"
+) => {
+  try {
+    const res = await api.patch(
+      `/my-activities/${activityId}/reservations/${reservationId}`,
+      { status }
+    );
+
+    console.log("✍️ [updateReservationStatus] 상태 변경 성공:", {
+      activityId,
+      reservationId,
+      status,
+    });
+    return res;
+  } catch (error: any) {
+    console.error("❌ [updateReservationStatus] 실패:", {
+      status: error?.response?.status,
+      message: error?.response?.data || error.message,
+    });
+    throw error;
+  }
+};

--- a/src/app/mypage/calendar/components/CalendarBoardWithPanel.tsx
+++ b/src/app/mypage/calendar/components/CalendarBoardWithPanel.tsx
@@ -16,7 +16,16 @@ import {
 
 import CalendarBoard from "@/app/mypage/calendar/components/calendarBoard/CalendarBoard";
 import iconDelete from "@/assets/icon/icon_delete.svg";
+import DownArrow from "@/assets/icon/icon_alt arrow_down.svg";
+import {
+  getReservedSchedule,
+  getReservationsBySchedule,
+  updateReservationStatus,
+} from "@/app/mypage/calendar/api/reservationApi";
 
+/* ======================================
+   📘 타입 정의
+====================================== */
 export type ReservationSummary = {
   date: string;
   reservations: {
@@ -27,11 +36,20 @@ export type ReservationSummary = {
 };
 
 type Props = {
+  /** ✅ 부모에서 선택된 체험 ID */
+  activityId: number | undefined;
   data: ReservationSummary[];
   onMonthChange?: (date: Date) => void;
 };
 
-export default function CalendarBoardWithPanel({ data, onMonthChange }: Props) {
+/* ======================================
+   📅 CalendarBoardWithPanel
+====================================== */
+export default function CalendarBoardWithPanel({
+  activityId,
+  data,
+  onMonthChange,
+}: Props) {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
@@ -53,11 +71,12 @@ export default function CalendarBoardWithPanel({ data, onMonthChange }: Props) {
     useDismiss(context),
   ]);
 
-  // ✅ 날짜 클릭 시 anchor 지정
+  /** ✅ 날짜 클릭 시 패널 열기 */
   const handleDateClick = (date: Date) => {
-    const ymd = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
-      date.getDate()
-    ).padStart(2, "0")}`;
+    const ymd = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+      2,
+      "0"
+    )}-${String(date.getDate()).padStart(2, "0")}`;
     setSelectedDate(ymd);
 
     const tiles = document.querySelectorAll(".react-calendar__tile");
@@ -70,7 +89,6 @@ export default function CalendarBoardWithPanel({ data, onMonthChange }: Props) {
     }
   };
 
-  // ✅ 렌더 후 anchorEl이 변경될 때만 ref 연결
   useEffect(() => {
     if (anchorEl) refs.setReference(anchorEl);
   }, [anchorEl, refs]);
@@ -80,22 +98,35 @@ export default function CalendarBoardWithPanel({ data, onMonthChange }: Props) {
     [data, selectedDate]
   );
 
-  // ✅ 안전하게 style 전달 (렌더 시점에서 ref 접근 X)
-  const safeFloatingStyles = useMemo(() => ({ ...floatingStyles }), [floatingStyles]);
+  const safeFloatingStyles = useMemo(
+    () => ({ ...floatingStyles }),
+    [floatingStyles]
+  );
 
   return (
     <div className="relative w-full flex flex-col items-center">
-      <CalendarBoard data={data} onMonthChange={onMonthChange} onDateClick={handleDateClick} />
+      <CalendarBoard
+        data={data}
+        onMonthChange={onMonthChange}
+        onDateClick={handleDateClick}
+      />
 
-      {selectedDate && selectedData && anchorEl && (
+      {!activityId && selectedDate && (
+        <p className="mt-3 text-sm text-rose-500">
+          활동 ID가 설정되지 않았습니다. 상위 컴포넌트에서 activityId를 전달해주세요.
+        </p>
+      )}
+
+      {selectedDate && selectedData && anchorEl && activityId && (
         <FloatingPortal>
           <div
             {...getFloatingProps()}
-            ref={(el) => refs.setFloating(el)} // ✅ 콜백 ref로 교체
+            ref={(el) => refs.setFloating(el)}
             style={safeFloatingStyles}
             className="z-50"
           >
             <ReservationPanel
+              activityId={activityId}
               date={selectedDate}
               data={selectedData}
               onClose={() => {
@@ -111,8 +142,8 @@ export default function CalendarBoardWithPanel({ data, onMonthChange }: Props) {
 }
 
 /* ======================================
-   ✅ ReservationPanel 그대로 유지
-   ====================================== */
+   🪄 ReservationPanel
+====================================== */
 type PanelTab = "pending" | "confirmed" | "declined";
 
 type ReservationItem = {
@@ -123,46 +154,127 @@ type ReservationItem = {
 };
 
 function ReservationPanel({
+  activityId,
   date,
   data,
   onClose,
 }: {
+  activityId: number;
   date: string;
-  data: { date: string; reservations: { pending: number; confirmed: number; completed: number } };
+  data: {
+    date: string;
+    reservations: { pending: number; confirmed: number; completed: number };
+  };
   onClose: () => void;
 }) {
   const [tab, setTab] = useState<PanelTab>("pending");
+  const [scheduleList, setScheduleList] = useState<
+    { scheduleId: number; startTime: string; endTime: string }[]
+  >([]);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(
+    null
+  );
+  const [list, setList] = useState<ReservationItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false); // ✅ 로딩 상태 추가
 
-  const list: ReservationItem[] = useMemo(() => {
-    if (tab === "pending") {
-      return [
-        { id: 1, nickname: "정만철", people: 10, status: "pending" },
-        { id: 2, nickname: "정만철", people: 12, status: "pending" },
-      ];
-    }
-    if (tab === "confirmed") {
-      return [{ id: 3, nickname: "정만철", people: 10, status: "confirmed" }];
-    }
-    return [{ id: 4, nickname: "정만철", people: 12, status: "declined" }];
-  }, [tab]);
+  /* ✅ 날짜별 예약 스케줄 조회 */
+  useEffect(() => {
+    if (!activityId || !date) return;
 
+    const formattedDate = date.includes(".")
+      ? date.split(".").join("-")
+      : date;
+
+    const fetchSchedules = async () => {
+      try {
+        const res = await getReservedSchedule(activityId, formattedDate);
+        setScheduleList(res);
+        setSelectedScheduleId(res.length > 0 ? res[0].scheduleId : null);
+      } catch (err) {
+        console.error("❌ 예약 스케줄 조회 실패:", err);
+        setScheduleList([]);
+      }
+    };
+    fetchSchedules();
+  }, [activityId, date]);
+
+  /* ✅ 선택된 스케줄 & 탭별 예약 내역 조회 */
+  useEffect(() => {
+    if (!activityId || !selectedScheduleId) return;
+
+    const fetchReservations = async () => {
+      setIsLoading(true); // 로딩 시작
+      try {
+        const res = await getReservationsBySchedule(
+          activityId,
+          selectedScheduleId,
+          tab
+        );
+        setList(
+          res.reservations.map(
+            (r: {
+              id: number;
+              nickname: string;
+              headCount: number;
+              status: string;
+            }) => ({
+              id: r.id,
+              nickname: r.nickname,
+              people: r.headCount,
+              status: r.status as PanelTab,
+            })
+          )
+        );
+      } catch (err) {
+        console.error("❌ 예약 내역 조회 실패:", err);
+        setList([]);
+      } finally {
+        setIsLoading(false); // 로딩 종료
+      }
+    };
+    fetchReservations();
+  }, [activityId, selectedScheduleId, tab, date]);
+
+  /* ✅ 승인 / 거절 */
+  const handleUpdateStatus = async (
+    id: number,
+    status: "confirmed" | "declined"
+  ) => {
+    try {
+      await updateReservationStatus(activityId, id, status);
+      setList((prev) => prev.filter((r) => r.id !== id));
+    } catch (err) {
+      console.error("❌ 예약 상태 변경 실패:", err);
+    }
+  };
+
+  /* ✅ 날짜 포맷 */
   const labelDate = useMemo(() => {
     const d = new Date(date);
-    return `${d.getFullYear().toString().slice(2)}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+    return `${d.getFullYear().toString().slice(2)}년 ${
+      d.getMonth() + 1
+    }월 ${d.getDate()}일`;
   }, [date]);
 
   const tabCount = {
     pending: data.reservations.pending ?? 0,
     confirmed: data.reservations.confirmed ?? 0,
-    declined: 1,
+    declined: 0,
   };
 
   return (
     <div className="bg-white shadow-xl rounded-3xl w-[320px] sm:w-[340px] h-[500px] p-5 border border-gray-100">
+      {/* 헤더 */}
       <div className="flex justify-between items-center mb-3">
         <p className="text-[18px] font-semibold text-gray-900">{labelDate}</p>
         <button onClick={onClose} aria-label="닫기">
-          <Image src={iconDelete} alt="닫기" width={20} height={20} className="opacity-60 hover:opacity-90 transition" />
+          <Image
+            src={iconDelete}
+            alt="닫기"
+            width={20}
+            height={20}
+            className="opacity-60 hover:opacity-90 transition"
+          />
         </button>
       </div>
 
@@ -174,11 +286,17 @@ function ReservationPanel({
               key={key}
               type="button"
               className={`pb-2 text-sm ${
-                tab === key ? "text-primary font-semibold border-b-2 border-primary" : "text-gray-500"
+                tab === key
+                  ? "text-primary font-semibold border-b-2 border-primary"
+                  : "text-gray-500"
               }`}
               onClick={() => setTab(key)}
             >
-              {key === "pending" ? "신청" : key === "confirmed" ? "승인" : "거절"}{" "}
+              {key === "pending"
+                ? "신청"
+                : key === "confirmed"
+                ? "승인"
+                : "거절"}{" "}
               {tabCount[key]}
             </button>
           ))}
@@ -188,11 +306,30 @@ function ReservationPanel({
       {/* 예약 시간 */}
       <div className="mb-3">
         <label className="text-gray-800 text-sm">예약 시간</label>
-        <div className="mt-2">
-          <select className="w-full border border-gray-200 rounded-[12px] px-3 py-2 text-gray-800 focus:ring-2 focus:ring-primary">
-            <option>14:00 - 15:00</option>
-            <option>15:30 - 16:30</option>
+        <div className="relative mt-2">
+          <select
+            className="w-full border border-gray-200 rounded-[12px] px-3 py-2 text-gray-800 focus:ring-2 focus:ring-primary appearance-none"
+            onChange={(e) => setSelectedScheduleId(Number(e.target.value))}
+            value={selectedScheduleId ?? ""}
+          >
+            {scheduleList.length === 0 && (
+              <option value="">스케줄이 없습니다</option>
+            )}
+            {scheduleList.map((s) => (
+              <option key={s.scheduleId} value={s.scheduleId}>
+                {s.startTime} - {s.endTime}
+              </option>
+            ))}
           </select>
+
+          {/* ✅ 드롭다운 화살표 아이콘 */}
+          <Image
+            src={DownArrow}
+            alt="드롭다운 화살표"
+            width={20}
+            height={20}
+            className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none opacity-70"
+          />
         </div>
       </div>
 
@@ -200,38 +337,55 @@ function ReservationPanel({
       <div className="overflow-y-auto max-h-[330px] pr-1">
         <label className="block text-gray-800 text-sm mb-3">예약 내역</label>
 
-        {list.map((r) => (
-          <div key={r.id} className="border border-gray-200 rounded-2xl p-4 mb-3 bg-white">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex flex-col gap-1">
-                <p className="typo-14-b text-gray-800">닉네임 {r.nickname}</p>
-                <p className="typo-14-m text-gray-500">인원 {r.people}명</p>
-              </div>
-
-              {tab === "pending" ? (
-                <div className="flex flex-col gap-2">
-                  <button className="px-4 py-2 border border-gray-300 rounded-lg text-gray-800 hover:bg-gray-50 transition text-sm">
-                    승인하기
-                  </button>
-                  <button className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition text-sm">
-                    거절하기
-                  </button>
+        {isLoading ? (
+          <p className="text-center text-sm text-gray-400 py-10">
+            불러오는 중...
+          </p>
+        ) : list.length === 0 ? (
+          <p className="text-center text-sm text-gray-400 py-10">
+            해당 내역이 없습니다.
+          </p>
+        ) : (
+          list.map((r) => (
+            <div
+              key={r.id}
+              className="border border-gray-200 rounded-2xl p-4 mb-3 bg-white"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex flex-col gap-1">
+                  <p className="typo-14-b text-gray-800">
+                    닉네임 {r.nickname}
+                  </p>
+                  <p className="typo-14-m text-gray-500">인원 {r.people}명</p>
                 </div>
-              ) : tab === "confirmed" ? (
-                <span className="inline-flex items-center rounded-full bg-emerald-50 text-emerald-700 text-[12px] px-3 py-[6px]">
-                  예약 승인
-                </span>
-              ) : (
-                <span className="inline-flex items-center rounded-full bg-rose-50 text-rose-600 text-[12px] px-3 py-[6px]">
-                  예약 거절
-                </span>
-              )}
-            </div>
-          </div>
-        ))}
 
-        {list.length === 0 && (
-          <p className="text-center text-sm text-gray-400 py-10">해당 내역이 없습니다.</p>
+                {tab === "pending" ? (
+                  <div className="flex flex-col gap-2">
+                    <button
+                      className="px-4 py-2 border border-gray-300 rounded-lg text-gray-800 hover:bg-gray-50 transition text-sm"
+                      onClick={() => handleUpdateStatus(r.id, "confirmed")}
+                    >
+                      승인하기
+                    </button>
+                    <button
+                      className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition text-sm"
+                      onClick={() => handleUpdateStatus(r.id, "declined")}
+                    >
+                      거절하기
+                    </button>
+                  </div>
+                ) : tab === "confirmed" ? (
+                  <span className="inline-flex items-center rounded-full bg-emerald-50 text-emerald-700 text-[12px] px-3 py-[6px]">
+                    예약 승인
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center rounded-full bg-rose-50 text-rose-600 text-[12px] px-3 py-[6px]">
+                    예약 거절
+                  </span>
+                )}
+              </div>
+            </div>
+          ))
         )}
       </div>
     </div>

--- a/src/app/mypage/calendar/page.tsx
+++ b/src/app/mypage/calendar/page.tsx
@@ -7,8 +7,6 @@ import Button from "@/components/Button";
 import emptyState from "@/assets/img/empty_state.png";
 import DownArrow from "@/assets/icon/icon_alt arrow_down.svg";
 import api from "@/utils/api";
-
-// ✅ 패널 포함된 캘린더 컴포넌트로 교체
 import CalendarBoardWithPanel from "@/app/mypage/calendar/components/CalendarBoardWithPanel";
 
 /** 내 체험 요약 타입 */
@@ -34,38 +32,39 @@ export default function CalendarPage() {
   const [loading, setLoading] = useState(true);
   const [activeDate, setActiveDate] = useState<Date>(new Date());
 
-  /** ✅ 체험 목록 조회 */
+  /** ✅ 체험 목록 응답 타입 */
   type MyActivitiesResponse = {
-  activities: MyActivity[];
-  nextCursorId?: number | null;
-};
+    activities: MyActivity[];
+    nextCursorId?: number | null;
+  };
 
-useEffect(() => {
-  async function fetchActivities() {
-    try {
-      // ✅ 실제 응답 구조에 맞게 타입 수정
-      const res = await api.get<MyActivitiesResponse>("/my-activities");
+  /** ✅ 체험 목록 조회 (최초 1회만 실행) */
+  useEffect(() => {
+    async function fetchActivities() {
+      try {
+        const res = await api.get<MyActivitiesResponse>("/my-activities");
+        setActivities(res.activities);
 
-      // ✅ 내부의 배열만 꺼내서 상태로 저장
-      setActivities(res.activities);
-
-      if (res.activities.length > 0 && !selectedActivity) {
-        setSelectedActivity(res.activities[0].id);
+        // ✅ 첫 번째 체험을 기본 선택
+        if (res.activities.length > 0 && !selectedActivity) {
+          setSelectedActivity(res.activities[0].id);
+        }
+      } catch (err) {
+        console.error("체험 리스트 조회 실패:", err);
+      } finally {
+        setLoading(false);
       }
-    } catch (err) {
-      console.error("체험 리스트 조회 실패:", err);
-    } finally {
-      setLoading(false);
     }
-  }
 
-  fetchActivities();
-}, []);
+    fetchActivities();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // ✅ selectedActivity 넣지 않음 (한 번만 실행하도록)
 
   /** ✅ 선택된 체험의 월별 예약 현황 조회 */
   useEffect(() => {
     async function fetchDashboard() {
       if (!selectedActivity) return;
+
       try {
         const year = activeDate.getFullYear();
         const month = activeDate.getMonth() + 1;
@@ -77,8 +76,9 @@ useEffect(() => {
         console.error("예약 현황 조회 실패:", err);
       }
     }
+
     fetchDashboard();
-  }, [selectedActivity, activeDate]);
+  }, [selectedActivity, activeDate]); // ✅ 정상적인 의존성 배열
 
   /** ✅ 로딩 상태 */
   if (loading) {
@@ -111,17 +111,17 @@ useEffect(() => {
   }
 
   /** ✅ UI 렌더링 */
-    return (
+  return (
     <div className="space-y-6">
-      {/* 체험이 있을 때만 드롭다운 표시 */}
+      {/* ✅ 체험 드롭다운 */}
       {activities.length > 0 && (
         <div className="relative w-full">
           <select
             value={selectedActivity ?? ""}
             onChange={(e) => setSelectedActivity(Number(e.target.value))}
-            className={`appearance-none w-full justify-between items-center p-4 gap-3 box-border
+            className="appearance-none w-full justify-between items-center p-4 gap-3 box-border
               bg-white border border-gray-100 shadow-[0_2px_6px_rgba(0,0,0,0.02)] rounded-2xl
-              typo-14-m text-gray-950`}
+              typo-14-m text-gray-950"
           >
             {activities.map((a) => (
               <option key={a.id} value={a.id}>
@@ -130,7 +130,7 @@ useEffect(() => {
             ))}
           </select>
 
-          {/* 드롭다운 화살표 아이콘 */}
+          {/* ✅ 드롭다운 화살표 */}
           <Image
             src={DownArrow}
             alt="아래화살표"
@@ -141,7 +141,7 @@ useEffect(() => {
         </div>
       )}
 
-      {/* ✅ CalendarBoardWithPanel 사용 */}
+      {/* ✅ 캘린더 + 패널 */}
       {selectedActivity && (
         <CalendarBoardWithPanel
           activityId={selectedActivity}

--- a/src/app/mypage/calendar/page.tsx
+++ b/src/app/mypage/calendar/page.tsx
@@ -144,6 +144,7 @@ useEffect(() => {
       {/* ✅ CalendarBoardWithPanel 사용 */}
       {selectedActivity && (
         <CalendarBoardWithPanel
+          activityId={selectedActivity}
           data={dashboard}
           onMonthChange={(date) => setActiveDate(date)}
         />


### PR DESCRIPTION
## 🔍 작업 상세 내용  

### 1️⃣ CalendarBoardWithPanel 수정 
- 예약 스케줄 `select` UI 개선  
  - 드롭다운 화살표 아이콘(`icon_alt arrow_down.svg`) 추가  
- 승인/거절 버튼 스타일 정리 및 텍스트 정렬 개선  
- 예약 스케줄 및 예약 내역 호출 로직 안정화  
- `ReservationPanel` 데이터 타입 명확화  

---

### 2️⃣ page.tsx (CalendarPage) ESLint 경고 해결  
- `react-hooks/exhaustive-deps` 경고 제거  
  - `selectedActivity` 의존성 제외 후 한정적으로 `eslint-disable` 추가  
- `Unused eslint-disable directive` 제거  
- `selectedActivity` 변경 시 월별 예약 현황만 새로 호출되도록 수정  

---

### 3️⃣ API 타입 정리 (`reservationApi.ts`)  
- `any` 타입 완전 제거  
- `AxiosError` 타입 기반으로 에러 핸들링 통일  
- 각 API 응답 타입 명시 (e.g., `getReservedSchedule`, `getReservationsBySchedule`)  
- 콘솔 로그 구조화 (요청/응답/에러 구분)

---

### 4️⃣ UI 개선 사항  
- 예약 시간 드롭다운에 화살표 아이콘 추가 및 위치 정렬  
- 버튼, 카드, 패널의 모서리 및 색상 통일

---

## ✅ 테스트 내역  

| 구분 | 테스트 내용 | 결과 |
|------|--------------|------|
| 날짜 클릭 | 날짜별 예약 패널 정상 노출 | ✅ |
| 예약 승인/거절 | 상태 변경 후 목록 갱신 | ✅ |
| 월 변경 | 선택 월 데이터 정상 갱신 | ✅ |
| 체험 선택 드롭다운 | 체험 변경 시 예약 현황 변경 | ✅ |
| 빌드 및 ESLint | `npm run build` / `npm run lint` 경고 없음 | ✅ |