### PR TITLE
[feature/experience]체험 등록 페이지 - 기본 예약 슬롯 노출 및 가격 placeholder 미표시 문제 수정

### DIFF
--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -25,7 +25,7 @@ export default function ExperienceRegisterPage() {
     description: "",
     address: "",
     price: 0,
-    schedules: [{ date: "", startTime: "", endTime: "" }],
+    schedules: [],
     bannerImageUrl: "",
     subImageUrls: [],
   });
@@ -199,9 +199,14 @@ export default function ExperienceRegisterPage() {
         <div className="mb-6">
           <div className="mb-2 typo-16-b text-gray-950">가격</div>
           <Input
-            value={form.price}
+            value={form.price === 0 ? "" : form.price.toString()}
             placeholder="체험 금액을 입력해 주세요"
-            onChange={(e) => handleChange("price", Number(e.target.value))}
+            onChange={(e) =>
+              handleChange(
+                "price",
+                e.target.value === "" ? 0 : Number(e.target.value),
+              )
+            }
           />
         </div>
 


### PR DESCRIPTION
## 📌 진행사항

- 체험 등록 페이지(`ExperienceRegisterPage`)에서 기본 예약 슬롯(`-버튼 있는 슬롯`)이 렌더링되던 문제 수정  
  → `form.schedules` 초기값을 빈 배열(`[]`)로 변경하여 해결  
- 가격 입력란에서 `price` 값이 `0`일 경우 placeholder(`체험 금액을 입력해 주세요`)가 표시되지 않던 현상 수정  
  → `value`가 빈 문자열일 때만 표시되도록 조건 수정
## 🖼️ 스크린샷/이미지

### 💰 가격 placeholder 수정  
| Before | After |
|--------|--------|
| ![before-price](https://github.com/user-attachments/assets/8a36186d-ec08-4482-9f10-b11720aa7566) | ![after-price](https://github.com/user-attachments/assets/ea07a49f-b49c-4a7c-8f89-9aabd83e7cd7) |

---

### 🕒 예약 가능한 시간대 초기 슬롯 노출 수정  
| Before | After |
|--------|--------|
| ![before-slot](https://github.com/user-attachments/assets/c0f1acfd-6969-4304-8259-ec9e36eb5f3e) | ![after-price](https://github.com/user-attachments/assets/0f6db8ef-2a2d-4a83-899a-4600df8303ef) |
