### PR TITLE
[feature/experience-detail] 체험 상세 페이지 소개 이미지 1~4 장일 때의 레이아웃 깨짐 없도록 수정

### DIFF
--- a/src/components/experience-detail/ExperienceDetailImages.tsx
+++ b/src/components/experience-detail/ExperienceDetailImages.tsx
@@ -25,12 +25,12 @@ export default function ExperienceDetailImages({
     <section className="pt-8 lg:pt-0">
       {/* 이미지가 없을 때 */}
       {!images?.length ? (
-        <div className="w-full aspect-[4/3] bg-gray-100 rounded-2xl flex items-center justify-center text-gray-500">
+        <div className="w-full aspect-[4/3] h-[245px] md:h-[400px] bg-gray-100 rounded-2xl flex items-center justify-center text-gray-500">
           이미지가 없습니다
         </div>
       ) : images.length === 1 ? (
         // 1장일 때: 크게 하나만
-        <div className="w-full aspect-[4/3]">
+        <div className="w-full aspect-[4/3] h-[245px] md:h-[400px]">
           <img
             src={images[0].imageUrl}
             alt="대표 이미지"
@@ -39,7 +39,7 @@ export default function ExperienceDetailImages({
         </div>
       ) : images.length === 2 ? (
         // 2장일 때: 반반 배치
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 grid-rows-1 gap-3 h-[245px] md:h-[400px]">
           <img
             src={images[0].imageUrl}
             alt="소개 이미지 1"
@@ -72,13 +72,13 @@ export default function ExperienceDetailImages({
         </div>
       ) : (
         // 4장 이상: 기본 2열 그리드
-        <div className="grid grid-cols-2 gap-3">
-          {images.map((img, idx) => (
+        <div className="grid grid-cols-2 grid-rows-2 gap-3 h-[245px] md:h-[400px]">
+          {images.slice(0, 4).map((img, idx) => (
             <img
               key={img.id}
               src={img.imageUrl}
               alt={`체험 이미지 ${img.id}`}
-              className={`w-full h-auto object-cover ${getCornerClass(
+              className={`w-full h-full object-cover ${getCornerClass(
                 idx,
                 images.length,
               )}`}


### PR DESCRIPTION
## 📌 진행사항
- [x] 체험 상세 페이지 소개 이미지 1~4 장일 때의 레이아웃 깨짐 없도록 수정

## 🖼️ 스크린샷 / 이미지

#### 순차적으로 1~4장 일 때의 레이아웃 입니다. (혹시나 소개 이미지가 올라가지 않을 경우 배너 이미지 1장으로 표시됩니다)

<img width="1822" height="1087" alt="스크린샷 2025-10-28 오전 12 08 33" src="https://github.com/user-attachments/assets/af06f143-28fa-4efc-a6fc-0bec4f91d4ef" />
→ 소개 이미지가 1장일 때

<img width="1822" height="1087" alt="스크린샷 2025-10-28 오전 12 08 10" src="https://github.com/user-attachments/assets/7a1b09d7-8cbb-4466-b6b6-5f76254cd284" />
→ 소개 이미지가 2장일 때

<img width="1822" height="1087" alt="스크린샷 2025-10-28 오전 12 03 19" src="https://github.com/user-attachments/assets/e822477a-4a7e-4a5a-b8af-6094eeb00420" />
→ 소개 이미지가 3장일 때

<img width="1822" height="1087" alt="스크린샷 2025-10-28 오전 12 03 06" src="https://github.com/user-attachments/assets/d0d79bb2-753b-4705-8685-ad1f601a7aec" />
→ 소개 이미지가 4장일 때
