### PR TITLE
[feature/experience detail] 체험 상세 페이지 드롭다운 삭제 메뉴 기능 구현 및 삭제 조건 추가

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -101,7 +101,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input(
           ref={ref}
           type={effectiveType}
           className={clsx(
-            "w-full rounded-2xl md:rounded-3xl bg-white dark:bg-gray-900",
+            "w-full rounded-2xl bg-white dark:bg-gray-900",
             "px-4 py-5",
             hasLeading && "pl-11",
             "typo-14-m text-text-primary placeholder:text-text-secondary/60",

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,11 +7,11 @@ interface ModalProps {
   open: boolean;
   title?: string;
   children?: React.ReactNode;
-  confirmText?: string;        // 기본: "확인"
-  cancelText?: string;         // 비우면 자동으로 취소 버튼 숨김
+  confirmText?: string; // 기본: "확인"
+  cancelText?: string; // 비우면 자동으로 취소 버튼 숨김
   onClose?: () => void;
   onConfirm?: () => void;
-  showCancel?: boolean;        // 기본: true
+  showCancel?: boolean; // 기본: true
   /** 외부에서 폭 클래스 오버라이드 (예: "max-w-sm" 또는 "w-[320px] sm:w-[400px]") */
   widthClass?: string;
   /** 버튼 영역의 최대 폭 오버라이드 (예: "max-w-[260px] sm:max-w-[340px]") */
@@ -36,7 +36,8 @@ export default function Modal({
 
   // 기본값 + 외부 오버라이드
   const widthClass = widthClassProp ?? "w-[320px] sm:w-[400px]";
-  const actionsMaxClass = actionsMaxClassProp ?? "max-w-[260px] sm:max-w-[340px]";
+  const actionsMaxClass =
+    actionsMaxClassProp ?? "max-w-[260px] sm:max-w-[340px]";
 
   // ✅ Hook을 조건부 return 이전에 호출
   const Actions = React.useMemo(() => {
@@ -58,7 +59,7 @@ export default function Modal({
         <div
           className={clsx(
             "mt-6 grid grid-cols-2 gap-3 mx-auto w-full",
-            actionsMaxClass
+            actionsMaxClass,
           )}
         >
           <Button
@@ -96,7 +97,11 @@ export default function Modal({
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center">
       {/* 반투명 배경 */}
-      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden />
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden
+      />
 
       {/* 모달 본체 */}
       <div
@@ -105,7 +110,7 @@ export default function Modal({
         className={clsx(
           "relative text-center bg-white dark:bg-gray-900 rounded-[24px] shadow-xl border border-border-default p-[30px]",
           widthClass,
-          "max-w-[calc(100vw-2rem)]"
+          "max-w-[calc(100vw-2rem)]",
         )}
       >
         {/* 제목 */}

--- a/src/components/experience-detail/ExperienceDetailInfo.tsx
+++ b/src/components/experience-detail/ExperienceDetailInfo.tsx
@@ -2,11 +2,16 @@
 
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import React, { useState } from "react";
+
 import starIcon from "@/assets/icon/icon_star_on.svg";
 import mapIcon from "@/assets/icon/icon_map.svg";
-import MoreIcon from "@/assets/icon/icon_more.svg";
+import moreIcon from "@/assets/icon/icon_more.svg";
+import warningStateImg from "@/assets/img/warning_state.png";
 
 import Dropdown from "@/components/Dropdown";
+import Modal from "@/components/Modal";
+import { deleteActivity } from "@/app/mypage/experience/api/activities";
 
 interface ExperienceDetailInfoProps {
   title: string;
@@ -28,12 +33,26 @@ export default function ExperienceDetailInfo({
   id,
 }: ExperienceDetailInfoProps) {
   const router = useRouter();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const handleOwnerAction = (option: string) => {
     if (option === "수정하기") {
       router.push(`/experience-edit/${id}`);
     } else if (option === "삭제하기") {
-      console.log("삭제 모달 오픈");
+      setIsDeleteModalOpen(true);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await deleteActivity(Number(id));
+      alert("체험이 삭제되었습니다.");
+      router.push("/");
+    } catch (err) {
+      console.error(err);
+      alert("삭제 중 오류가 발생했습니다.");
+    } finally {
+      setIsDeleteModalOpen(false);
     }
   };
 
@@ -74,16 +93,42 @@ export default function ExperienceDetailInfo({
 
       {/* 등록자 표시 */}
       {isOwner && (
-        <div className="absolute right-0 top-0">
+        <div className="absolute top-5 -right-3 lg:top-0">
           <Dropdown
             trigger="click"
-            customIcon={MoreIcon}
+            customIcon={moreIcon}
             options={["수정하기", "삭제하기"]}
             onSelect={handleOwnerAction}
             highlightSelected={false}
           />
         </div>
       )}
+
+      <Modal
+        open={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        confirmText="네"
+        cancelText="아니요"
+        onConfirm={handleDeleteConfirm}
+        widthClass="w-80 md:w-100"
+        actionsMaxClass="max-w-[234px] md:max-w-[282px]"
+      >
+        <div className="-mt-3 flex flex-col items-center justify-center">
+          {/* 상단 경고 아이콘 */}
+          <Image
+            src={warningStateImg}
+            alt="경고 아이콘"
+            width={48}
+            height={48}
+            className="w-12 h-12 md:w-[88px] md:h-[88px]"
+          />
+
+          {/* 문구 */}
+          <h3 className="typo-16-b md:text-lg text-gray-950">
+            체험을 삭제하시겠습니까?
+          </h3>
+        </div>
+      </Modal>
     </section>
   );
 }

--- a/src/components/experience-detail/ExperienceDetailInfo.tsx
+++ b/src/components/experience-detail/ExperienceDetailInfo.tsx
@@ -12,6 +12,7 @@ import warningStateImg from "@/assets/img/warning_state.png";
 import Dropdown from "@/components/Dropdown";
 import Modal from "@/components/Modal";
 import { deleteActivity } from "@/app/mypage/experience/api/activities";
+import { getReservationDashboard } from "@/app/mypage/calendar/api/reservationApi";
 
 interface ExperienceDetailInfoProps {
   title: string;
@@ -45,11 +46,39 @@ export default function ExperienceDetailInfo({
 
   const handleDeleteConfirm = async () => {
     try {
+      const now = new Date();
+      const year = now.getFullYear().toString();
+      const month = String(now.getMonth() + 1).padStart(2, "0");
+
+      // 예약 현황 조회
+      const res = await getReservationDashboard(Number(id), year, month);
+      const reservationData = Array.isArray(res) ? res : [];
+
+      interface ReservationSummary {
+        date: string;
+        reservations: {
+          completed: number;
+          confirmed: number;
+          pending: number;
+        };
+      }
+
+      // 예약 상태 검사
+      const hasPendingOrConfirmed = reservationData.some(
+        (r: ReservationSummary) =>
+          r.reservations.pending > 0 || r.reservations.confirmed > 0,
+      );
+
+      if (hasPendingOrConfirmed) {
+        alert("신청 예약이 있는 체험은 삭제할 수 없습니다.");
+        return;
+      }
+
       await deleteActivity(Number(id));
       alert("체험이 삭제되었습니다.");
       router.push("/");
-    } catch (err) {
-      console.error(err);
+    } catch (err: unknown) {
+      console.error("삭제 중 오류:", err);
       alert("삭제 중 오류가 발생했습니다.");
     } finally {
       setIsDeleteModalOpen(false);


### PR DESCRIPTION
## 📌 진행사항
- [x] 체험 상세 페이지 드롭다운 메뉴에서 체험 삭제 기능 구현
- [x] 체험 상세 페이지 드롭다운 삭제하기 클릭 시 예약 현황 검사 후 삭제 제한 기능 추가

## 🔧 추후 수정/보완 예정
- 지금은 일단 체험 삭제 성공 알림이 기본 alert로 뜨고 있는데 추후 별도의 토스트로 전환하는게 좋을 듯 합니다.

## 🖼️ 스크린샷 / 이미지

<img width="1822" height="1087" alt="스크린샷 2025-10-28 오전 4 28 02" src="https://github.com/user-attachments/assets/51c4a50b-8104-460f-9641-c25bb3b29862" />

<img width="1822" height="1087" alt="스크린샷 2025-10-28 오전 4 28 09" src="https://github.com/user-attachments/assets/d619a620-34a2-4097-9331-bf0eed7cae6a" />
