### PR TITLE
[feature/experience] 예약된 일정 삭제 시 alert 경고창 및 DateSection 리렌더링 데이터 최신화 처리

### DIFF
--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -21,6 +21,7 @@ import Image from "next/image";
 import warning from "@/assets/img/warning_state.png";
 import api from "@/utils/api";
 import { updateActivity } from "@/app/mypage/experience/api/activities";
+import axios from "axios";
 
 export default function ExperienceEditPage() {
   const router = useRouter();
@@ -37,6 +38,7 @@ export default function ExperienceEditPage() {
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
+  const [dateSectionKey, setDateSectionKey] = useState(0);
 
   // ✅ 기존 체험 데이터 불러오기
   const { data, isLoading } = useQuery<
@@ -92,6 +94,28 @@ export default function ExperienceEditPage() {
       setIsModalOpen(true);
       setIsDirty(false);
     },
+    onError: (error) => {
+      if (axios.isAxiosError(error)) {
+        const message =
+          error.response?.data?.message ?? "수정 중 오류가 발생했습니다.";
+        alert(message);
+        //activityDetail 최신화
+        queryClient.invalidateQueries({ queryKey: ["activityDetail", id] });
+
+        //DateSection 리렌더 유도
+        setDateSectionKey((prev) => prev + 1);
+
+        //form의 schedules를 새로 세팅 (기존 data 기반)
+        if (data?.schedules) {
+          setForm((prev) => ({
+            ...prev!,
+            schedules: [...(data.schedules as Slot[])],
+          }));
+        }
+      } else {
+        alert("알 수 없는 오류가 발생했습니다.");
+      }
+    },
   });
   const handleChange = <
     K extends keyof (CreateActivityRequest & {
@@ -124,7 +148,7 @@ export default function ExperienceEditPage() {
       return;
     }
 
-    // ✅ 스케줄 로직
+    // 스케줄 로직
     const originalSchedules = (data?.schedules ?? []) as Slot[];
 
     const schedulesToAdd = (form.schedules as Slot[])
@@ -142,7 +166,7 @@ export default function ExperienceEditPage() {
         )
         .map((s) => s.id!) ?? [];
 
-    // ✅ 서브 이미지 로직 (id와 imageUrl 둘 다 존재)
+    // 서브 이미지 로직 (id와 imageUrl 둘 다 존재)
     const originalSubImages = data?.subImages ?? [];
     const currentSubImages = form.subImages ?? [];
 
@@ -302,6 +326,7 @@ export default function ExperienceEditPage() {
         {/* 예약 가능한 시간대 */}
         <div className="mb-6">
           <DateSection
+            key={dateSectionKey}
             value={form.schedules as Slot[]}
             onChange={(schedules) => handleChange("schedules", schedules)}
           />
@@ -322,7 +347,7 @@ export default function ExperienceEditPage() {
           <div className="mb-2 typo-16-b text-gray-950">소개 이미지 등록</div>
           <PhotoSection
             limit={4}
-            // ✅ PhotoSection은 string[]을 받기 때문에 imageUrl만 추출
+            // PhotoSection은 string[]을 받기 때문에 imageUrl만 추출
             value={form.subImages?.map((img) => img.imageUrl) ?? []}
             onChange={(urls) => {
               const updatedSubImages = urls.map((url) => {


### PR DESCRIPTION
### 💡 개요
예약된 일정이 포함된 체험을 **내 체험 수정 페이지**에서 삭제 시,
수정이 완료되지 않거나 UI가 갱신되지 않는 문제를 해결했습니다.

이전에는 백엔드에서 오류 메시지를 반환하더라도,
프론트엔드에서 DateSection이 즉시 갱신되지 않아 사용자가 혼동하는 이슈가 있었습니다.

### 📌 작업 내용 
- onError 시 alert() 추가 → **백엔드 에러 메시지를 사용자에게 즉시 표시**
- `DateSection` 컴포넌트에 `key` props 추가 → **강제 리렌더링 트리거**
- `onError` 시 `queryClient.invalidateQueries(['activityDetail', id])` 호출 → **백엔드 데이터 최신화**
- `form.schedules` 값을 최신 데이터(`data.schedules`)로 재세팅 → **UI 반영 지연 방지**
- 전체 페이지 리로딩(`window.location.reload`) 제거 → **성능 최적화**

### 🖼️ 스크린샷
**[예약된 일정 삭제 시 alert 경고창 및 리렌더링]**
![예약 가능한 시간대](https://github.com/user-attachments/assets/0438da7d-b764-438d-be84-27ebba124439)
 
