### PR TITLE
[feature/experience] 뒤로가기 시 이탈 모달 미노출 문제 수정

### DIFF
--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Modal from "@/components/Modal";
 import Input from "@/components/Input";
@@ -27,6 +27,7 @@ export default function ExperienceEditPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const params = useParams<{ id: string }>();
+  const pathname = usePathname();
   const id = Number(params.id);
   const [form, setForm] = useState<
     | (CreateActivityRequest & {
@@ -40,7 +41,7 @@ export default function ExperienceEditPage() {
   const [isDirty, setIsDirty] = useState(false);
   const [dateSectionKey, setDateSectionKey] = useState(0);
 
-  // ✅ 기존 체험 데이터 불러오기
+  // 기존 체험 데이터 불러오기
   const { data, isLoading } = useQuery<
     CreateActivityRequest & {
       id: number;
@@ -65,7 +66,7 @@ export default function ExperienceEditPage() {
     const t = setTimeout(() => {
       setForm({
         ...data,
-        subImages: data.subImages ?? [], // ✅ subImages 존재 안 하면 빈 배열로 초기화
+        subImages: data.subImages ?? [], // subImages 존재 안 하면 빈 배열로 초기화
       });
     }, 0);
     return () => clearTimeout(t);
@@ -214,10 +215,21 @@ export default function ExperienceEditPage() {
   useEffect(() => {
     if (!isDirty) return;
 
-    const handlePopState = (e: PopStateEvent) => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      Object.defineProperty(e, "returnValue", {
+        configurable: true,
+        value: "",
+      });
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    // 뒤로가기(라우터 pop) 감지
+    const handlePop = (e: PopStateEvent) => {
       e.preventDefault();
       setPendingUrl("/mypage/experience");
       setIsLeaveModalOpen(true);
+      history.pushState(null, "", pathname); // 스택 복원
     };
 
     const handleLinkClick = (e: MouseEvent) => {
@@ -237,15 +249,16 @@ export default function ExperienceEditPage() {
       setIsLeaveModalOpen(true);
     };
 
-    window.addEventListener("popstate", handlePopState);
+    window.addEventListener("popstate", handlePop);
     document.addEventListener("click", handleLinkClick, true);
     history.pushState(null, "", window.location.href);
 
     return () => {
-      window.removeEventListener("popstate", handlePopState);
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("popstate", handlePop);
       document.removeEventListener("click", handleLinkClick);
     };
-  }, [isDirty]);
+  }, [isDirty, pathname]);
 
   const handleLeaveConfirm = () => {
     setIsLeaveModalOpen(false);
@@ -255,6 +268,8 @@ export default function ExperienceEditPage() {
   const handleLeaveCancel = () => {
     setPendingUrl(null);
     setIsLeaveModalOpen(false);
+
+    router.push(pathname);
   };
 
   const SAMPLE_OPTIONS = [

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createActivity } from "@/app/mypage/experience/api/activities";
 import { ApiError, CreateActivityRequest } from "@/types/experience";
@@ -18,7 +18,7 @@ import warning from "@/assets/img/warning_state.png";
 export default function ExperienceRegisterPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
-
+  const pathname = usePathname();
   const [form, setForm] = useState<CreateActivityRequest>({
     title: "",
     category: "",
@@ -93,23 +93,30 @@ export default function ExperienceRegisterPage() {
     }
   };
 
-  // 페이지 이탈 감지
   useEffect(() => {
     if (!isDirty) return;
 
-    // 브라우저 뒤로가기 감지
-    const handlePopState = (e: PopStateEvent) => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       e.preventDefault();
-      setPendingUrl("/mypage/experience"); // 명시적으로 뒤로가기 시 이동할 경로 지정
+      Object.defineProperty(e, "returnValue", {
+        configurable: true,
+        value: "",
+      });
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    // 뒤로가기(라우터 pop) 감지
+    const handlePop = (e: PopStateEvent) => {
+      e.preventDefault();
+      setPendingUrl("/mypage/experience");
       setIsLeaveModalOpen(true);
+      history.pushState(null, "", pathname); // 스택 복원
     };
 
-    // 링크 클릭 감지 (로고, 프로필 등)
     const handleLinkClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
       const anchor = target?.closest("a") as HTMLAnchorElement | null;
       if (!anchor) return;
-
       const href = anchor.getAttribute("href");
       if (
         !href ||
@@ -118,21 +125,21 @@ export default function ExperienceRegisterPage() {
         href.startsWith("tel:")
       )
         return;
-
       e.preventDefault();
       setPendingUrl(href);
       setIsLeaveModalOpen(true);
     };
 
-    window.addEventListener("popstate", handlePopState);
+    window.addEventListener("popstate", handlePop);
     document.addEventListener("click", handleLinkClick, true);
     history.pushState(null, "", window.location.href);
 
     return () => {
-      window.removeEventListener("popstate", handlePopState);
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("popstate", handlePop);
       document.removeEventListener("click", handleLinkClick);
     };
-  }, [isDirty]);
+  }, [isDirty, pathname]);
 
   // “예” → 이동하려던 페이지로
   const handleLeaveConfirm = () => {


### PR DESCRIPTION
### 💡개요
체험 수정 페이지(`ExperienceEditPage`)에서 뒤로가기 클릭 시 이탈 모달이 한 번만 뜨고, 
두 번째 클릭부터는 이벤트가 감지되지 않던 문제를 수정했습니다.

### 🚨 문제 원인
- 뒤로가기(popstate) 이벤트 감지를 위해 `history.pushState`를 사용했지만,
  한 번 모달을 띄운 뒤 “아니오”를 누르면 스택이 한 단계 줄어 popstate가 더 이상 발생하지 않았음.
- App Router 환경에서 직접 `window.history` 조작 시 라우터 내부 스택과 불일치 발생.

### 📌진행사항 
- “아니오” 클릭 시 `router.push(pathname)`을 이용해 Next.js Router 기준으로 스택 복원
- `popstate` 이벤트에서 `history.pushState`를 즉시 복원하여 연속 뒤로가기도 정상 동작
- `beforeunload` 경고창 로직 개선  
  → `Object.defineProperty(e, 'returnValue', ...)` 사용으로 TS 경고 제거 및 호환성 유지
- `popstate` 및 링크 클릭(`a` 태그) 모두에서 동일한 이탈 모달 동작하도록 정리

### ✅ 테스트 시나리오
| 시나리오 | 기대 동작 |
|-----------|------------|
| 뒤로가기 1회 | 이탈 모달 표시 |
| “아니오” 클릭 후 다시 뒤로가기 | 다시 이탈 모달 표시 |
| “예” 클릭 | `/mypage/experience`로 정상 이동 |
| 저장 완료 후 뒤로가기 | 모달 표시 안 됨 |
| 새로고침 / 탭 닫기 | 브라우저 기본 confirm 표시 |

### 🖼️스크린샷
**[여러번 뒤로가기 시 이탈 모달 계속 띄우기]**
![이탈모달 에러핸들링](https://github.com/user-attachments/assets/19c096d2-bf22-4908-ae52-76d8ee78031d)


