### PR TITLE
[feature/experience] 내 체험 등록/수정 완료 후 클릭 불가 현상 해결 및 '스포츠' 카테고리 추가

### DIFF
--- a/src/app/experience-edit/[id]/page.tsx
+++ b/src/app/experience-edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Modal from "@/components/Modal";
@@ -41,6 +41,33 @@ export default function ExperienceEditPage() {
   const [isDirty, setIsDirty] = useState(false);
   const [dateSectionKey, setDateSectionKey] = useState(0);
 
+  // -----------------------------
+  // 변경: 핸들러 레퍼런스와 정리 함수 추가
+  // (이전에는 useEffect 안에서만 정의되어 외부에서 제거 불가하여
+  //  일부 경우에 클릭 차단 리스너가 남아 있는 문제 발생)
+  // -----------------------------
+  const beforeUnloadRef = useRef<(e: BeforeUnloadEvent) => void | null>(null);
+  const popstateRef = useRef<(e: PopStateEvent) => void | null>(null);
+  const linkClickRef = useRef<(e: MouseEvent) => void | null>(null);
+
+  const removeDirtyListeners = () => {
+    try {
+      if (beforeUnloadRef.current)
+        window.removeEventListener("beforeunload", beforeUnloadRef.current);
+      if (popstateRef.current)
+        window.removeEventListener("popstate", popstateRef.current);
+      if (linkClickRef.current)
+        document.removeEventListener("click", linkClickRef.current, true);
+    } catch (e) {
+      // 안전하게 무시
+      // console.warn("removeDirtyListeners error", e);
+    } finally {
+      beforeUnloadRef.current = null;
+      popstateRef.current = null;
+      linkClickRef.current = null;
+    }
+  };
+
   // 기존 체험 데이터 불러오기
   const { data, isLoading } = useQuery<
     CreateActivityRequest & {
@@ -72,6 +99,66 @@ export default function ExperienceEditPage() {
     return () => clearTimeout(t);
   }, [data, form]);
 
+  // -----------------------------
+  // 변경: isDirty에 따라 전역 리스너를 등록/해제 (리스너는 ref에 저장)
+  // 이렇게 하면 컴포넌트 외부(예: mutation.onSuccess)에서도 제거 가능
+  // -----------------------------
+  useEffect(() => {
+    if (!isDirty) {
+      // isDirty가 false로 바뀌면 즉시 리스너 정리
+      removeDirtyListeners();
+      return;
+    }
+
+    // 정의 후 ref에 저장
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      Object.defineProperty(e, "returnValue", {
+        configurable: true,
+        value: "",
+      });
+    };
+    beforeUnloadRef.current = handleBeforeUnload;
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    const handlePop = (e: PopStateEvent) => {
+      e.preventDefault();
+      setPendingUrl("/mypage/experience");
+      setIsLeaveModalOpen(true);
+      history.pushState(null, "", pathname); // 스택 복원
+    };
+    popstateRef.current = handlePop;
+    window.addEventListener("popstate", handlePop);
+
+    const handleLinkClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest("a") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (
+        !href ||
+        href.startsWith("#") ||
+        href.startsWith("mailto:") ||
+        href.startsWith("tel:")
+      )
+        return;
+      e.preventDefault();
+      setPendingUrl(href);
+      setIsLeaveModalOpen(true);
+    };
+    linkClickRef.current = handleLinkClick;
+    document.addEventListener("click", handleLinkClick, true);
+
+    // 기본 pushState (원래 코드 유지)
+    history.pushState(null, "", window.location.href);
+
+    return () => {
+      // cleanup: ref 기반으로 안전하게 제거
+      removeDirtyListeners();
+    };
+    // pathname 포함: 뒤로가기/복원 시 핸들 동작을 현재 경로로 유지
+  }, [isDirty, pathname]);
+
   const mutation = useMutation({
     mutationFn: async (payload: UpdateActivityRequest) =>
       updateActivity(id, payload),
@@ -92,8 +179,13 @@ export default function ExperienceEditPage() {
       queryClient.invalidateQueries({ queryKey: ["myActivities"] });
       queryClient.invalidateQueries({ queryKey: ["activityDetail", id] });
 
+      // -----------------------------
+      // 변경: 성공 시 isDirty 플래그만 끄는 것이 아니라
+      // 리스너도 즉시 제거해서 이후 전역 클릭이 차단되지 않도록 함
+      // -----------------------------
+      removeDirtyListeners(); // 추가
+      setIsDirty(false); // 이후 safePush 등에서 정상 동작
       setIsModalOpen(true);
-      setIsDirty(false);
     },
     onError: (error) => {
       if (axios.isAxiosError(error)) {
@@ -118,6 +210,7 @@ export default function ExperienceEditPage() {
       }
     },
   });
+
   const handleChange = <
     K extends keyof (CreateActivityRequest & {
       subImages?: { id?: number; imageUrl: string }[];
@@ -215,53 +308,15 @@ export default function ExperienceEditPage() {
   useEffect(() => {
     if (!isDirty) return;
 
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      Object.defineProperty(e, "returnValue", {
-        configurable: true,
-        value: "",
-      });
-    };
-    window.addEventListener("beforeunload", handleBeforeUnload);
-
-    // 뒤로가기(라우터 pop) 감지
-    const handlePop = (e: PopStateEvent) => {
-      e.preventDefault();
-      setPendingUrl("/mypage/experience");
-      setIsLeaveModalOpen(true);
-      history.pushState(null, "", pathname); // 스택 복원
-    };
-
-    const handleLinkClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      const anchor = target?.closest("a") as HTMLAnchorElement | null;
-      if (!anchor) return;
-      const href = anchor.getAttribute("href");
-      if (
-        !href ||
-        href.startsWith("#") ||
-        href.startsWith("mailto:") ||
-        href.startsWith("tel:")
-      )
-        return;
-      e.preventDefault();
-      setPendingUrl(href);
-      setIsLeaveModalOpen(true);
-    };
-
-    window.addEventListener("popstate", handlePop);
-    document.addEventListener("click", handleLinkClick, true);
-    history.pushState(null, "", window.location.href);
-
-    return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
-      window.removeEventListener("popstate", handlePop);
-      document.removeEventListener("click", handleLinkClick);
-    };
-  }, [isDirty, pathname]);
+    // 이전 로직은 useEffect 상단에서 처리하도록 옮겨졌음 (ref 기반)
+    // 이 effect only ensures listener lifecycle already handled above.
+  }, [isDirty]);
 
   const handleLeaveConfirm = () => {
     setIsLeaveModalOpen(false);
+    // 사용자 확인 후 실제 이동: 먼저 리스너 정리
+    removeDirtyListeners(); // 안전하게 제거
+    setIsDirty(false);
     router.push(pendingUrl || "/mypage/experience");
   };
 
@@ -275,6 +330,7 @@ export default function ExperienceEditPage() {
   const SAMPLE_OPTIONS = [
     { label: "문화 · 예술", value: "문화 · 예술" },
     { label: "식음료", value: "식음료" },
+    { label: "스포츠", value: "스포츠" },
     { label: "투어", value: "투어" },
     { label: "관광", value: "관광" },
     { label: "웰빙", value: "웰빙" },

--- a/src/app/experience-register/page.tsx
+++ b/src/app/experience-register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createActivity } from "@/app/mypage/experience/api/activities";
@@ -19,6 +19,7 @@ export default function ExperienceRegisterPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const pathname = usePathname();
+
   const [form, setForm] = useState<CreateActivityRequest>({
     title: "",
     category: "",
@@ -31,14 +32,39 @@ export default function ExperienceRegisterPage() {
   });
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false); // 이탈 확인 모달 상태
-  const [pendingUrl, setPendingUrl] = useState<string | null>(null); // 사용자가 가려던 목적지 URL을 잠시 저장해둠
-  const [isDirty, setIsDirty] = useState(false); // 작성 중 여부
+  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false);
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
 
+  // 리스너 참조 저장용 ref
+  const beforeUnloadRef = useRef<(e: BeforeUnloadEvent) => void | null>(null);
+  const popstateRef = useRef<(e: PopStateEvent) => void | null>(null);
+  const linkClickRef = useRef<(e: MouseEvent) => void | null>(null);
+
+  // 리스너 안전 제거 함수
+  const removeDirtyListeners = () => {
+    try {
+      if (beforeUnloadRef.current)
+        window.removeEventListener("beforeunload", beforeUnloadRef.current);
+      if (popstateRef.current)
+        window.removeEventListener("popstate", popstateRef.current);
+      if (linkClickRef.current)
+        document.removeEventListener("click", linkClickRef.current, true);
+    } catch (e) {
+      // 무시
+    } finally {
+      beforeUnloadRef.current = null;
+      popstateRef.current = null;
+      linkClickRef.current = null;
+    }
+  };
+
+  // 등록 mutation
   const { mutate, isPending } = useMutation({
     mutationFn: (payload: CreateActivityRequest) => createActivity(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["myActivities"] });
+      removeDirtyListeners(); // 추가: 성공 시 리스너 제거
       setIsDirty(false);
       setIsModalOpen(true);
     },
@@ -52,6 +78,15 @@ export default function ExperienceRegisterPage() {
       console.error("등록 실패:", err);
     },
   });
+
+  // 폼 변경 시 dirty 상태 설정
+  const handleChange = (
+    key: keyof CreateActivityRequest,
+    value: string | number | string[] | CreateActivityRequest["schedules"],
+  ) => {
+    setIsDirty(true);
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
 
   const handleSubmit = () => {
     if (
@@ -74,16 +109,7 @@ export default function ExperienceRegisterPage() {
     safePush("/mypage/experience");
   };
 
-  // 폼 변경 시 dirty 상태 설정
-  const handleChange = (
-    key: keyof CreateActivityRequest,
-    value: string | number | string[] | CreateActivityRequest["schedules"],
-  ) => {
-    setIsDirty(true);
-    setForm((prev) => ({ ...prev, [key]: value }));
-  };
-
-  // 커스텀 push 함수로 라우터 이동 감지
+  // 커스텀 push (isDirty 시 이탈 확인)
   const safePush = (url: string) => {
     if (isDirty) {
       setPendingUrl(url);
@@ -93,8 +119,14 @@ export default function ExperienceRegisterPage() {
     }
   };
 
+  // 리스너 관리
   useEffect(() => {
-    if (!isDirty) return;
+    if (!isDirty) {
+      removeDirtyListeners();
+      return;
+    }
+
+    removeDirtyListeners(); // 기존 리스너 먼저 제거
 
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       e.preventDefault();
@@ -103,15 +135,17 @@ export default function ExperienceRegisterPage() {
         value: "",
       });
     };
+    beforeUnloadRef.current = handleBeforeUnload;
     window.addEventListener("beforeunload", handleBeforeUnload);
 
-    // 뒤로가기(라우터 pop) 감지
     const handlePop = (e: PopStateEvent) => {
       e.preventDefault();
       setPendingUrl("/mypage/experience");
       setIsLeaveModalOpen(true);
-      history.pushState(null, "", pathname); // 스택 복원
+      history.pushState(null, "", pathname);
     };
+    popstateRef.current = handlePop;
+    window.addEventListener("popstate", handlePop);
 
     const handleLinkClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
@@ -129,26 +163,24 @@ export default function ExperienceRegisterPage() {
       setPendingUrl(href);
       setIsLeaveModalOpen(true);
     };
-
-    window.addEventListener("popstate", handlePop);
+    linkClickRef.current = handleLinkClick;
     document.addEventListener("click", handleLinkClick, true);
+
     history.pushState(null, "", window.location.href);
 
     return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
-      window.removeEventListener("popstate", handlePop);
-      document.removeEventListener("click", handleLinkClick);
+      removeDirtyListeners();
     };
   }, [isDirty, pathname]);
 
-  // “예” → 이동하려던 페이지로
+  // 이탈 확인 모달
   const handleLeaveConfirm = () => {
     setIsLeaveModalOpen(false);
-    const targetUrl = pendingUrl || "/mypage/experience";
-    router.push(targetUrl);
+    removeDirtyListeners();
+    setIsDirty(false);
+    router.push(pendingUrl || "/mypage/experience");
   };
 
-  // “아니오” → 현재 페이지 유지
   const handleLeaveCancel = () => {
     setPendingUrl(null);
     setIsLeaveModalOpen(false);
@@ -157,6 +189,7 @@ export default function ExperienceRegisterPage() {
   const SAMPLE_OPTIONS = [
     { label: "문화 · 예술", value: "문화 · 예술" },
     { label: "식음료", value: "식음료" },
+    { label: "스포츠", value: "스포츠" },
     { label: "투어", value: "투어" },
     { label: "관광", value: "관광" },
     { label: "웰빙", value: "웰빙" },
@@ -259,7 +292,7 @@ export default function ExperienceRegisterPage() {
             label={isPending ? "등록 중..." : "등록하기"}
             variant="primary"
             size="md"
-            onClick={() => handleSubmit()}
+            onClick={handleSubmit}
             disabled={isPending}
           />
         </div>


### PR DESCRIPTION
### 💡주요 변경 사항
1. **이벤트 리스너 생명주기 개선**
   - 등록(`ExperienceRegisterPage`) 및 수정(`ExperienceEditPage`) 페이지에서
     완료 모달 닫은 뒤에도 클릭이 불가능하던 문제 해결
   - 원인: useEffect 내부에서 등록된 전역 이벤트 리스너가 cleanup 시
     정확히 같은 함수 참조로 제거되지 않아 pointer-events가 막힘
   - 해결: `useRef` 기반으로 핸들러 참조 저장 후 `removeDirtyListeners()` 함수로 일괄 제거

2. **모달 종료 후 정상 상호작용 복원**
   - 모달 닫힘 후 로고, 사이드 메뉴, 헤더 버튼 등 클릭 가능하도록 개선
   - `mutation.onSuccess`, `handleLeaveConfirm` 등 주요 타이밍에서 리스너 해제 추가

3. **카테고리 항목 추가**
   - `스포츠` 카테고리 추가

### ✅ 테스트 항목
- [x] 등록 완료 후 모달 닫고 로고/사이드메뉴 클릭 정상 작동
- [x] 수정 완료 후 모달 닫고 로고/사이드메뉴 클릭 정상 작동
- [x] dirty 상태일 때 뒤로가기 및 링크 클릭 시 이탈 확인 모달 정상 표시
- [x] 카테고리 드롭다운에서 ‘스포츠’ 항목 선택 가능

