### PR TITLE
[feature/mainpage] 공용 카드 컴포넌트 디자인 복구 및 GNB 드롭다운 메뉴 공용 컴포넌트로 변경

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -51,8 +51,7 @@ const CardRoot: React.FC<CardProps> = ({ className, children }) => (
     className={clsx(
       "relative w-[132px] md:w-82 lg:w-[262px] rounded-2xl md:rounded-3xl bg-white dark:bg-gray-900",
       "shadow-[0_8px_24px_-8px_rgba(0,0,0,0.12)]",
-      // ✅ 수정된 높이: 모바일 h-136px, PC md:h-200px
-      "h-[136px] md:h-[200px] overflow-hidden transition-shadow",
+      "overflow-hidden transition-shadow",
       className,
     )}
   >
@@ -68,9 +67,8 @@ const CardRoot: React.FC<CardProps> = ({ className, children }) => (
  */
 const CardImage: React.FC<CardImageProps> = ({ src, alt, className }) => (
   <div
-    // ✅ 수정된 이미지 높이: 모바일 h-80px, PC md:h-120px (전체 카드 높이에 맞춰 조정됨)
     className={clsx(
-      "w-full h-[80px] md:h-[120px] rounded-[20px] overflow-hidden",
+      "w-full h-[176px] md:h-[299px] rounded-[20px] overflow-hidden",
       className,
     )}
   >
@@ -86,7 +84,6 @@ const CardImage: React.FC<CardImageProps> = ({ src, alt, className }) => (
  */
 const CardContent: React.FC<CardContentProps> = ({ className, children }) => (
   <div
-    // 겹치는 높이도 조정될 수 있지만, 기존 값을 유지합니다.
     className={clsx(
       "relative z-10 -mt-[33px] md:-mt-[60px]",
       "rounded-2xl md:rounded-3xl bg-white dark:bg-gray-900",
@@ -154,7 +151,6 @@ const CardPrice: React.FC<CardPriceProps> = ({
 );
 
 /* ---------- BottomSpacer (선택) ---------- */
-// 카드가 고정 높이가 되었으므로, Card.BottomSpacer는 굳이 필요하지 않을 수 있습니다.
 const CardBottomSpacer: React.FC = () => <div className="h-5" />;
 
 /* ---------- 합치기 (컴파운드) ---------- */

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -103,7 +103,7 @@ export default function Dropdown({
       {/* 드롭다운 */}
       <div
         className={clsx(
-          "mt-2 absolute right-0 min-w-fit rounded-lg border border-gray-100 bg-white shadow-md z-50 transition-all duration-150 whitespace-nowrap",
+          "mt-2 absolute right-0 min-w-fit rounded-lg border border-gray-100 bg-white shadow-md z-50 transition-all duration-150 whitespace-nowrap overflow-hidden",
           isOpen
             ? "opacity-100 translate-y-0 pointer-events-auto"
             : "opacity-0 -translate-y-2 pointer-events-none",

--- a/src/components/GNB.tsx
+++ b/src/components/GNB.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from "@/app/store/useAuthStore"; // zustand 스토어 im
 import Logo from "@/assets/img/logo_gnb.svg";
 import BellIcon from "@/assets/icon/icon_bell.svg";
 import NotificationPopover from "@/features/notifications/NotificationPopover";
+import Dropdown from "@/components/Dropdown";
 
 type GNBProps = {
   /** 안읽은 알림 개수 (선택). 주어지면 헤더 벨 아이콘에 뱃지 표시 */
@@ -21,7 +22,7 @@ type GNBProps = {
   userName?: string;
 };
 
-export default function GNB({ 
+export default function GNB({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   unread = 0, // ✅ 이제 사용하지 않지만 레거시 호환성 유지
   onLogout,
@@ -30,7 +31,6 @@ export default function GNB({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   userName: __,
 }: GNBProps) {
-  
   // ✅ zustand 스토어에서 로그인 상태 직접 가져오기 (props 무시)
   const { user, logout } = useAuthStore();
   const isLoggedIn = !!user;
@@ -43,17 +43,20 @@ export default function GNB({
   // 외부 클릭 감지
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setDropdownOpen(false);
       }
     }
 
     if (dropdownOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener("mousedown", handleClickOutside);
     }
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [dropdownOpen]);
 
@@ -69,7 +72,12 @@ export default function GNB({
   // 마이페이지 이동
   const handleMyPage = () => {
     setDropdownOpen(false);
-    router.push('/mypage');
+    router.push("/mypage");
+  };
+
+  const handleSelect = (option: string) => {
+    if (option === "마이페이지") handleMyPage();
+    else if (option === "로그아웃") handleLogout();
   };
 
   return (
@@ -88,7 +96,7 @@ export default function GNB({
               <button
                 type="button"
                 aria-label="알림"
-                className="relative h-8 w-8 flex items-center justify-center rounded-xl hover:bg-gray-50 transition"
+                className="relative h-8 w-8 flex items-center justify-center rounded-full hover:bg-gray-50 transition"
               >
                 <Image
                   src={BellIcon}
@@ -103,41 +111,14 @@ export default function GNB({
             </NotificationPopover>
 
             {/* 사용자 드롭다운 */}
-            <div className="relative" ref={dropdownRef}>
-              <button
-                onClick={() => setDropdownOpen(!dropdownOpen)}
-                className="h-8 px-3 rounded-xl hover:bg-gray-50 transition flex items-center gap-1 typo-12b text-gray-900"
-                aria-expanded={dropdownOpen}
-                aria-haspopup="menu"
-              >
-                {userName}
-                <svg 
-                  className={`w-4 h-4 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`}
-                  fill="none" 
-                  stroke="currentColor" 
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
-
-              {/* 드롭다운 메뉴 */}
-              {dropdownOpen && (
-                <div className="absolute right-0 mt-2 w-40 bg-white rounded-xl border border-border-default shadow-lg py-2 z-50">
-                  <button
-                    onClick={handleMyPage}
-                    className="w-full px-4 py-2 text-left typo-14-m text-gray-900 hover:bg-gray-50 transition"
-                  >
-                    마이페이지
-                  </button>
-                  <button
-                    onClick={handleLogout}
-                    className="w-full px-4 py-2 text-left typo-14-m text-gray-900 hover:bg-gray-50 transition"
-                  >
-                    로그아웃
-                  </button>
-                </div>
-              )}
+            <div ref={dropdownRef}>
+              <Dropdown
+                options={["마이페이지", "로그아웃"]}
+                onSelect={handleSelect} // 기존 핸들러 그대로 활용
+                label={userName}
+                trigger="click"
+                highlightSelected={false}
+              />
             </div>
           </nav>
         ) : (

--- a/src/components/main/PopularSection.tsx
+++ b/src/components/main/PopularSection.tsx
@@ -84,7 +84,6 @@ export default function PopularSection() {
     const nextIndex = currentIndex + visibleCount;
     if (nextIndex < activities.length) setCurrentIndex(nextIndex);
 
-    // ✅ 추가 로드 조건: 다음 인덱스가 거의 끝에 도달하면 fetch
     if (
       nextIndex + visibleCount >= activities.length - 2 &&
       hasMore &&


### PR DESCRIPTION
## 📌 진행사항
- [x] 메인 페이지에 사용되는 공용 카드 컴포넌트 디자인 복구
- [x] GNB 컴포넌트 내 사용되는 드롭다운 컴포넌트 공용 드롭다운 컴포넌트로 변경

## 🔧 추후 수정/보완 예정
- GNB 및 체험 상세 페이지 케밥 버튼 클릭으로 표시되는 드롭다운 메뉴 외부 클릭 시 닫힘 혹은 마우스 포인터 메뉴에서 벗어날 시 닫힘 기능 추가하는게 좋을 지 고민 중에 있습니다!

## 🖼️ 스크린샷 / 이미지

<img width="1822" height="1083" alt="스크린샷 2025-10-30 오후 7 53 30" src="https://github.com/user-attachments/assets/fde8325b-912d-4078-82ff-c4f740e6cb20" />

<img width="1822" height="1083" alt="스크린샷 2025-10-30 오후 7 54 27" src="https://github.com/user-attachments/assets/e6e898cc-2513-4082-a0cd-ff30f513d0f3" />
