### PR TITLE
FIX: 모바일 예약 카드 액션 버튼 및 레이아웃 오류 수정

### DIFF
--- a/src/app/mypage/bookings/page.tsx
+++ b/src/app/mypage/bookings/page.tsx
@@ -13,6 +13,31 @@ import warningImg from "@/assets/img/warning_state.png";
 import api from "@/utils/api";
 import { MyReservationsResponse, Reservation } from "@/types/reservation";
 
+// =======================================================================
+// ✅ 환경 감지 훅 추가
+// =======================================================================
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+  const mobileWidth = 768; // 일반적으로 태블릿/모바일 경계
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < mobileWidth);
+    };
+
+    handleResize(); 
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isMobile;
+};
+// =======================================================================
+
+
 type ReservationFilter =
   | "all"
   | "pending"
@@ -59,7 +84,9 @@ export default function BookingsPage() {
   const [loading, setLoading] = useState(true);
 
   const [filter, setFilter] = useState<ReservationFilter>("all");
-  const [openCardId, setOpenCardId] = useState<number | null>(null);
+  
+  // ✅ 모바일 환경 상태 가져오기
+  const isMobile = useIsMobile(); 
 
   const [openReviewModal, setOpenReviewModal] = useState(false);
   const [rating, setRating] = useState(0);
@@ -245,7 +272,6 @@ export default function BookingsPage() {
             key={f}
             onClick={() => {
               setFilter(f);
-              setOpenCardId(null);
             }}
             className={`px-4 py-2 rounded-full border ${
               filter === f
@@ -261,15 +287,12 @@ export default function BookingsPage() {
       {/* ✅ 예약 카드 */}
       {filtered.map((r) => (
         <div key={r.id}>
-          <div
-            className={`cursor-pointer transition-all ${
-              openCardId === r.id ? "ring-2 ring-primary/30 rounded-2xl" : ""
-            }`}
-            onClick={() =>
-              setOpenCardId((prev) => (prev === r.id ? null : r.id))
-            }
-          >
+          <div className="cursor-pointer transition-all"> 
             <ListCard
+              // ✅ ListCard에 환경 variant 전달 및 mx-auto로 중앙 정렬
+              variant={isMobile ? "mobile" : "pc"}
+              className="mx-auto" 
+              
               thumbnail={r.activity.bannerImageUrl}
               title={r.activity.title}
               subtitle={`${r.date} · ${r.startTime} - ${r.endTime}`}
@@ -282,52 +305,20 @@ export default function BookingsPage() {
                     : "후기 작성"
                   : undefined
               }
+              // ListCard 내부에서 액션 버튼을 렌더링하도록 콜백 함수만 전달합니다.
+              onClickCTA={() => {
+                setSelectedReservation(r);
+                setOpenReviewModal(true);
+              }}
+              onClickChange={() => router.push(`/experience-detail/${r.activity.id}`)}
+              onClickCancel={() => {
+                setTargetReservation(r);
+                setOpenCancelModal(true);
+              }}
             />
           </div>
 
-          {openCardId === r.id && (
-            <div className="mt-3 mb-4 flex justify-center gap-3">
-              {r.status === "pending" && (
-                <>
-                  <Button
-                    label="예약 변경"
-                    variant="secondary"
-                    className="w-1/3 h-11"
-                    onClick={() => router.push(`/experience-detail/${r.activity.id}`)}
-                  />
-                  <Button
-                    label="예약 취소"
-                    variant="outline"
-                    className="w-1/3 h-11"
-                    onClick={() => {
-                      setTargetReservation(r);
-                      setOpenCancelModal(true);
-                    }}
-                  />
-                </>
-              )}
-              {r.status === "completed" && (
-                r.reviewSubmitted ? (
-                  <Button
-                    label="후기 완료"
-                    variant="secondary"
-                    className="w-2/3 h-11 opacity-60 cursor-not-allowed"
-                    disabled
-                  />
-                ) : (
-                  <Button
-                    label="후기 작성"
-                    variant="primary"
-                    className="w-2/3 h-11"
-                    onClick={() => {
-                      setSelectedReservation(r);
-                      setOpenReviewModal(true);
-                    }}
-                  />
-                )
-              )}
-            </div>
-          )}
+          {/* ❌ 이전의 하단 액션 버튼 렌더링 영역 제거됨 */}
         </div>
       ))}
 
@@ -447,4 +438,4 @@ function filterLabel(key: ReservationFilter) {
     default:
       return "전체";
   }
-}
+} 

--- a/src/app/mypage/experience/mock/experienceMock 2.ts
+++ b/src/app/mypage/experience/mock/experienceMock 2.ts
@@ -1,0 +1,74 @@
+import streetdanceImg from "@/assets/img/streetdance_main.png";
+
+export interface Activity {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ExperienceResponse {
+  cursorId: number;
+  totalCount: number;
+  activities: Activity[];
+}
+
+export const experienceMockData: ExperienceResponse = {
+  cursorId: 0,
+  totalCount: 3,
+  activities: [
+    {
+      id: 1,
+      userId: 101,
+      title: "핸드드립 커피 클래스",
+      description:
+        "바리스타에게 직접 배우는 원데이 핸드드립 클래스 ☕️ 원두 선택부터 추출까지 실습 중심으로 진행됩니다.",
+      category: "음식/음료",
+      price: 45000,
+      address: "서울시 마포구 연남동",
+      bannerImageUrl: streetdanceImg.src,
+      rating: 4.9,
+      reviewCount: 58,
+      createdAt: "2025-10-10T14:00:00.000Z",
+      updatedAt: "2025-10-12T18:30:00.000Z",
+    },
+    {
+      id: 2,
+      userId: 101,
+      title: "캔들 메이킹 클래스",
+      description:
+        "자신만의 향을 담은 소이캔들을 만들어보세요. 향 조합과 디자인을 직접 선택할 수 있습니다.",
+      category: "공예",
+      price: 38000,
+      address: "서울시 성동구 성수동",
+      bannerImageUrl: streetdanceImg.src,
+      rating: 4.7,
+      reviewCount: 32,
+      createdAt: "2025-10-09T15:00:00.000Z",
+      updatedAt: "2025-10-12T10:00:00.000Z",
+    },
+    {
+      id: 3,
+      userId: 101,
+      title: "플라워 원데이 클래스",
+      description:
+        "계절 꽃으로 부케를 만들어보는 감성 플라워 클래스 🌸 초보자도 쉽게 따라 할 수 있어요.",
+      category: "플라워",
+      price: 55000,
+      address: "서울시 강남구 논현동",
+      bannerImageUrl: streetdanceImg.src,
+      rating: 4.8,
+      reviewCount: 41,
+      createdAt: "2025-10-08T12:00:00.000Z",
+      updatedAt: "2025-10-13T09:00:00.000Z",
+    },
+  ],
+};

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -2,6 +2,7 @@
 import clsx from "clsx";
 import Tag from "@/components/Tag";
 import Button from "@/components/Button";
+import { useState } from "react";
 
 export type ReservationStatus =
   | "pending"
@@ -9,8 +10,6 @@ export type ReservationStatus =
   | "declined"
   | "canceled"
   | "completed";
-
-// type MobileState = "done" | "ing"; // done=후기작성 / ing=예약변경·취소 // 모바일 코드 변경으로 사용 안함
 
 export interface ListCardProps {
   // 공통 필수
@@ -38,8 +37,6 @@ export interface ListCardProps {
 
   showActions?: boolean;
 
-  // 모바일 테스트용
-  // forceMobileState?: MobileState; // 모바일 코드 변경으로 사용 안함
   actionsDisabled?: boolean;
 }
 
@@ -71,13 +68,25 @@ export default function ListCard({
   onClickChange,
   onClickCancel,
   variant = "pc",
-  // forceMobileState, // 모바일 코드 변경으로 사용 안함
   actionsDisabled,
 }: ListCardProps) {
   const { v: tagVariant, t: tagText } = badge(status);
-  // const mobileState: MobileState =
-  //   forceMobileState ?? (status === "completed" ? "done" : "ing"); 모바일 코드 변경으로 사용 안함
   const hasSubtitle = !!subtitle?.trim();
+
+  // ✅ 모바일에서 사용할 내부 토글 상태
+  const [showMobileActions, setShowMobileActions] = useState(false);
+
+  // ✅ 카드 본체 클릭 핸들러: 모바일에서만 토글 기능을 수행
+  const handleCardClick = () => {
+    if (variant === "mobile") {
+      // 액션이 있는 상태일 때만 토글
+      if (status === "pending" || status === "completed") {
+          setShowMobileActions(!showMobileActions);
+      }
+    }
+    // PC에서는 클릭해도 아무 일 없음
+  };
+
 
   const ProgressActions = (
     <div className={clsx(variant === "mobile" ? "grid grid-cols-2 gap-3" : "flex gap-2")}>
@@ -118,19 +127,32 @@ export default function ListCard({
     />
   );
 
-  /* ───────────── MOBILE (시안 동일: 309/139, 38px 겹침, 버튼 410px) ───────────── */
+  /* ───────────── MOBILE (클릭 시 하단 버튼 토글) ───────────── */
   if (variant === "mobile") {
-    // 고정값: 카드 309, 이미지 139, 카드가 가리는 폭 38 → 밖으로 보이는 폭 101
-    // 총 너비(버튼 기준) = 309 + 101 = 410
+    // 원본 비율 (309px + 101px = 410px)을 유지하면서 가변 너비로 전환합니다.
+    const CARD_WIDTH_RATIO = "75.36%"; // 309 / 410
+    const IMAGE_WIDTH_RATIO = "34%";  // 139px 부분
+
     return (
-      <div className={clsx("relative w-[410px]", className)}>
-        {/* 이미지: 카드 뒤에 깔리고, 오른쪽으로 101px 노출되도록 right:0에 배치 */}
-        <div className="absolute right-0 top-0 -z-10 w-[139px] h-[139px] rounded-[20px] overflow-hidden">
+      // w-full, max-w-[410px]로 변경하여 가변 너비 및 최대 너비 제한
+      <div className={clsx("relative w-full max-w-[410px]", className)}>
+        
+        {/* 이미지: 오른쪽 139px 부분 */}
+        {/* ✅ 수정: w-[34%] 대신 style prop 사용 */}
+        <div 
+            className={`absolute right-0 top-0 -z-10 h-[139px] rounded-[20px] overflow-hidden`}
+            style={{ width: IMAGE_WIDTH_RATIO }} // <== 인라인 스타일 적용
+        >
           <img src={thumbnail} alt="" className="w-full h-full object-cover" loading="lazy" />
         </div>
 
-        {/* 카드: 폭 309, 높이 139, 이미지 위 38px 덮음 */}
-        <div className="relative z-0 h-[139px] w-[309px] rounded-[20px] bg-white border border-gray-100 shadow-[0_2px_8px_rgba(0,0,0,0.06)] overflow-hidden">
+        {/* 카드: 왼쪽 309px 부분 */}
+        {/* ✅ 수정: w-[75.36%] 대신 style prop 사용 */}
+        <div 
+          className="relative z-0 h-[139px] rounded-[20px] bg-white border border-gray-100 shadow-[0_2px_8px_rgba(0,0,0,0.06)] overflow-hidden cursor-pointer"
+          style={{ width: CARD_WIDTH_RATIO }} // <== 인라인 스타일 적용
+          onClick={handleCardClick}
+        >
           <div className="h-full px-5 py-5 flex flex-col justify-between">
             <div>
               {tagText && (
@@ -164,27 +186,29 @@ export default function ListCard({
           </div>
         </div>
 
-        {/* 버튼: 카드+이미지 전체 폭(410px)에 맞춤 */}
-        <div className="mt-3 w-[410px]">
-          {status === "completed"
-            ? DoneCTA
-            : status === "pending"
-            ? ProgressActions
-            : null}
-        </div>
+        {/* 버튼: w-full 유지 (문제 없음) */}
+        {showMobileActions && (
+          <div className="mt-3 w-full">
+            {status === "completed"
+              ? DoneCTA
+              : status === "pending"
+              ? ProgressActions
+              : null}
+          </div>
+        )}
       </div>
     );
   }
 
-  /* ───────────── PC ───────────── */
+  /* ───────────── PC (버튼 고정 표시) ───────────── */
   return (
     <div
       className={clsx(
         "flex items-stretch bg-white rounded-[20px] shadow-[0_2px_8px_rgba(0,0,0,0.05)] border border-gray-100 overflow-hidden",
-        // ✅ PC 높이를 200px로 고정
         "h-[200px]",
         className
       )}
+      onClick={handleCardClick}
     >
       {/* 좌 텍스트 */}
       <div className="flex-1 p-5 flex flex-col justify-between">
@@ -200,7 +224,6 @@ export default function ListCard({
           )}
           <div>
             <h4 className="typo-16-b text-text-primary mb-1 line-clamp-2">
-                {/* ✅ 제목이 2줄을 넘지 않도록 line-clamp-2 적용 (높이 유지 목적) */}
                 {title}
             </h4>
             {hasSubtitle ? (
@@ -215,6 +238,7 @@ export default function ListCard({
           </div>
         </div>
 
+        {/* PC 버튼 위치: 텍스트 영역의 하단 우측 (항상 표시됨) */}
         <div className="flex justify-between items-center mt-4">
           <div>
             <span className="typo-16-b text-text-primary">{price}</span>
@@ -229,7 +253,7 @@ export default function ListCard({
         </div>
       </div>
 
-      {/* 우 이미지: 카드 내부에서 꽉 차게, 높이 200px에 맞춰집니다. */}
+      {/* 우 이미지 */}
       <div className="w-[180px] shrink-0 overflow-hidden">
         <img
           src={thumbnail}


### PR DESCRIPTION
- BookingsPage.tsx에서 ListCard의 불필요한 부모 클릭 로직(openCardId) 및 하단 중복 액션 버튼 영역을 삭제.
- ListCard.tsx에서 variant prop을 useIsMobile을 통해 동적으로 전달받도록 BookingsPage.tsx 수정.
- ListCard.tsx 모바일 뷰에서 고정 픽셀 너비를 제거하고, 동적 너비(%)는 인라인 스타일로 적용하여 Tailwind CSS 파싱 오류로 인한 이미지 미표시 및 레이아웃 잘림 문제 해결.
- ListCard의 모바일 클릭 토글 로직을 컴포넌트 내부에서 자체적으로 관리하도록 변경하여 부모 컴포넌트 의존성 제거.


| 구분 | 내용 | 상세 수정 내역 | 삭제/추가/수정 이유 |
|:--:|--|--|--|
| 추가 🟢 | 환경 감지 훅 | 파일 상단에 `useIsMobile` 훅 정의 및 컴포넌트 내 `const isMobile = useIsMobile();` 추가. | `ListCard`가 모바일/PC 환경에 따라 다른 동작(클릭 토글 vs 고정 버튼)을 수행하도록 `variant` prop을 동적으로 전달하기 위해 추가. |
| 삭제 🔴 | openCardId 상태 | `const [openCardId, setOpenCardId] = useState<number \| null>(null);` 삭제. | `ListCard` 내부에서 자체적으로 onClick을 처리하도록 로직을 이관하여, 부모에서 중복으로 클릭 로직을 관리하지 않도록 정리. |
| 삭제 🔴 | 외부 카드 클릭 로직 | `filtered.map` 내 `<div onClick={() => ... }>` 및 `openCardId` 관련 클래스 바인딩 삭제. | `ListCard` 내부에서 자체적으로 onClick을 처리하도록 로직을 이관하여, 부모에서 중복으로 클릭 로직을 관리하지 않도록 정리. |
| 삭제 🔴 | 하단 중복 액션 버튼 | `openCardId === r.id` 조건으로 렌더링되던 큰 **"예약 변경/취소/후기 작성"** 버튼 영역 전체 삭제. | 모바일/PC 환경 모두 액션 버튼 렌더링을 `ListCard.tsx` 내부로 통합했으므로, 페이지 레벨에서 버튼을 중복으로 렌더링하는 코드를 제거하여 UI 중복 문제를 해결. |
| 수정 🟡 | ListCard variant 전달 | `ListCard` 호출 시 `variant={isMobile ? "mobile" : "pc"}` prop 추가. | `ListCard`가 현재 뷰포트 크기를 인식하여 모바일(onClick 토글) 또는 PC(고정 버튼) 로직을 실행하도록 유도. |
| 수정 🟡 | ListCard 중앙 정렬 | `ListCard` 호출 시 `className="mx-auto"` prop 추가. | 모바일 뷰에서 `ListCard`의 최대 너비(`max-w-[410px]`)가 적용될 때 화면 중앙에 위치하여 잘림이나 한쪽 쏠림 현상을 방지. |


