### PR TITLE
[feature/experience] 예약 승인된 체험 삭제 시 서버 에러 처리

### DIFF
--- a/src/app/mypage/experience/page.tsx
+++ b/src/app/mypage/experience/page.tsx
@@ -15,6 +15,7 @@ import warning from "@/assets/img/warning_state.png";
 import { ActivitiesResponse } from "@/types/experience";
 import api from "@/utils/api";
 import { deleteActivity } from "@/app/mypage/experience/api/activities";
+import axios from "axios";
 
 export default function ExperiencePage() {
   const router = useRouter();
@@ -127,11 +128,29 @@ export default function ExperiencePage() {
       });
       return { previous };
     },
-    onError: (_err, _id, context?: DeleteContext) => {
+    // ...existing code...
+    onError: (err, _id, context?: DeleteContext) => {
+      // 이전 캐시 복원
       if (context?.previous) {
         queryClient.setQueryData(["myActivities"], context.previous);
       }
-      alert("삭제 중 오류가 발생했습니다.");
+
+      // 서버 응답 메시지 우선 표출. axios 에러가 아니어도 가능한 메시지 표시
+      let serverMsg = "삭제 중 오류가 발생했습니다.";
+      if (axios.isAxiosError(err)) {
+        serverMsg =
+          err.response?.data?.message ||
+          (err.response?.data ? JSON.stringify(err.response.data) : serverMsg);
+        console.error("[deleteActivity] API Error:", err.response);
+      } else if (err instanceof Error) {
+        serverMsg = err.message;
+        console.error("[deleteActivity] Error:", err);
+      } else {
+        console.error("[deleteActivity] Unknown error:", err);
+      }
+
+      // 사용자에게 alert로 알림
+      alert(serverMsg);
     },
     onSuccess: () => {
       // 서버 기준으로 재동기화


### PR DESCRIPTION
### 🐞 예외 발견 및 수정
예약 승인된 활동을 삭제하려 할 때 400 오류가 발생했지만,
기존에는 단순히 “삭제 중 오류 발생” 메시지만 표시되어 원인을 알 수 없었습니다.

이에 따라 서버에서 전달하는 실제 오류 메시지를 사용자에게 표시하도록 수정했습니다.

### 🖼️스크린샷 
**[특정 예약이 있는 체험 삭제 불가 안내 alert창]**
<img width="1198" height="742" alt="image" src="https://github.com/user-attachments/assets/a272ea74-1c0e-4319-b02f-062350a908bd" />
